### PR TITLE
chore(ci): improve workflows + integrate manual changeset-driven release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,48 @@
+name: Changeset Check
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changeset-check:
+    name: Changeset required
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on non-user-facing PRs
+        id: skip
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qiE '^(chore|docs|test|refactor|ci|build|style)(\(|:|!)'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "PR title indicates a non-user-facing change; skipping changeset check."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.skip.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Verify a changeset is added on the branch
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # List .changeset/*.md files added on this branch since the
+          # PR's base commit. The base sha is fetched by checkout above.
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" -- '.changeset/*.md' | grep -v 'README.md' | grep -v 'config.json' || true)
+          if [ -z "$ADDED" ]; then
+            echo "::error::This PR introduces a user-visible change but adds no changeset."
+            echo "::error::Run \`bun changeset\` locally to create one, then commit it with the PR."
+            echo "::error::If this PR truly does not warrant a changelog entry, retitle it with one of: chore(, docs(, test(, refactor(, ci(, build(, style(."
+            exit 1
+          fi
+          echo "Changeset found:"
+          echo "$ADDED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,35 +4,102 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  ci:
-    name: Lint, Test, Build (Bun)
+  install:
+    name: Install
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - run: bun install --frozen-lockfile
+      - uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
 
-      - name: Install deps
-        run: bun install --frozen-lockfile
+  lint:
+    name: Lint
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun run lint
 
-      - name: Lint
-        run: bun run lint
+  typecheck:
+    name: Type Check
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun run typecheck
 
-      - name: Typecheck
-        run: bun run typecheck
+  test:
+    name: Tests
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun test
 
-      - name: Test
-        run: bun test
+  knip:
+    name: Knip
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun run knip:check
 
-      - name: Build
-        run: bun run build
-
-      - name: Show dist
-        run: ls -la dist
+  build:
+    name: Build
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Manual release flow: triggered by pushing a vX.Y.Z tag, never by a
+# push to main. The maintainer runs `bun changeset:version` locally to
+# bump versions + write CHANGELOG.md, commits, tags, and pushes the
+# tag. This workflow consumes the tag and ships the release.
 on:
   push:
     tags:
@@ -19,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -32,20 +36,37 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Extract tag name
-        id: tag_name
-        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Extract version + release notes
+        id: notes
+        run: |
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG_NAME#v}"
+          echo "tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Pull the section for this version out of CHANGELOG.md so
+          # the GitHub Release body matches the changelog entry exactly.
+          # The CHANGELOG starts a version with `## X.Y.Z`; we cut from
+          # that line up to (but not including) the next `## ` line.
+          if [ -f CHANGELOG.md ]; then
+            awk -v v="$VERSION" '
+              /^## / {
+                if (found) { exit }
+                if ($2 == v) { found = 1; next }
+              }
+              found { print }
+            ' CHANGELOG.md > release-notes.md
+          else
+            echo "_No CHANGELOG.md found; release notes generated from tag only._" > release-notes.md
+          fi
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag_name.outputs.TAG_NAME }}
-          release_name: Release ${{ steps.tag_name.outputs.TAG_NAME }}
-          body: |
-            Changes in this Release
-            - See [CHANGELOG.md](CHANGELOG.md) for details
+          tag_name: ${{ steps.notes.outputs.tag }}
+          name: Release ${{ steps.notes.outputs.tag }}
+          body_path: release-notes.md
           draft: false
           prerelease: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,58 @@ Rules:
 
 `no-console` is enforced (warn level). `console.warn` and `console.error` are allowed for genuine library-level warnings. `console.log` and `debugger` are not — remove them before committing. CI fails on `--max-warnings 0` so a stray `console.log` blocks the merge.
 
+## Changesets
+
+Every PR that introduces a user-visible change lands with a changeset file under `.changeset/`. The eventual CHANGELOG and version bump are derived from the accumulated changesets at release time, so dropping one means the change disappears from the release notes.
+
+### When to add a changeset
+
+**Add one** for: `feat`, `fix`, `perf`, breaking refactor, or anything that affects the published API or runtime behavior consumers will notice.
+
+**Skip** for: `chore`, `docs`, `test`, `refactor` (internal-only), `ci`, `build`, `style`. End-users don't care about these in a CHANGELOG.
+
+When in doubt, **add one**. They're cheap and easy to delete.
+
+### How to add one
+
+```bash
+bun changeset           # interactive: pick patch/minor/major, write summary
+# Edits a file at .changeset/<random-name>.md — commit it with the rest of the PR
+```
+
+The summary you write becomes the bullet in the next CHANGELOG entry, so write it for end users, not for reviewers.
+
+### Enforcement
+
+`changeset-check.yml` runs on every PR. It skips PRs whose title starts with `chore(`, `docs(`, `test(`, `refactor(`, `ci(`, `build(`, or `style(`. For all other PRs, it requires a `.changeset/*.md` file added on the branch and fails with a clear message otherwise.
+
+## Releasing
+
+Releases are **manual** by design. Multiple merged PRs accumulate changesets on `main`; the maintainer cuts a release when several are worth a coherent semver bump. Pushing to `main` runs CI but **never** publishes — only pushing a `vX.Y.Z` tag triggers `release.yml`.
+
+### Runbook
+
+```bash
+# Locally on main, after the wanted PRs are merged
+git checkout main && git pull
+
+# Apply changesets: bumps package.json version, writes CHANGELOG.md,
+# deletes the consumed changeset files
+bun changeset:version
+
+# Review the diff (version + CHANGELOG) and commit
+git diff
+git add . && git commit -m "chore(meta): release vX.Y.Z"
+
+# Tag the commit and push — release.yml fires on the tag
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+The flow is intentionally a few steps so the maintainer can review the bumped version and CHANGELOG before the release goes live.
+
+If `changeset:version` produces a version you don't want, edit `package.json` and `CHANGELOG.md` by hand before tagging — no shame in it. The downstream `release.yml` doesn't care how the tag arrived, only that the tag commit's working tree matches the version it advertises.
+
 ## Self-Review Before Declaring Done
 
 This section is **non-negotiable**. When you think the work on an issue is finished, **don't declare done immediately**. Run a self-review pass, fix what you find, and loop until the review is clean.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -22,9 +22,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const PARSERS_ROOT = path.resolve(__dirname, 'src/parsers')
 
 const parserScopes = readdirSync(PARSERS_ROOT)
-  .filter((entry) =>
-    statSync(path.join(PARSERS_ROOT, entry)).isDirectory()
-  )
+  .filter((entry) => statSync(path.join(PARSERS_ROOT, entry)).isDirectory())
   .map((dir) => `parsers/${dir}`)
   .sort()
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "format": "bunx prettier . -w",
     "knip:check": "bunx knip",
     "commitlint": "bunx commitlint --edit",
+    "changeset": "bunx changeset",
+    "changeset:status": "bunx changeset status --since=origin/main",
+    "changeset:version": "bunx changeset version",
+    "changeset:tag": "bunx changeset tag",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #12.

## Summary

Two concerns folded together because they touch the same \`.github/workflows/\` and the same release flow:

1. **CI hardening** — \`ci.yml\` now runs jobs in parallel with concurrency cancel-in-progress
2. **Changesets-driven release** — manual flow with PR-time enforcement and a modernized release workflow

## Three commits, each focused

- \`chore(ci): harden CI + add changeset enforcement + modernize release workflow\`
- \`chore(tooling): wire changeset scripts + flip access to public\`
- \`docs(meta): add Changesets and Releasing sections to CLAUDE.md\`

## CI hardening

- Concurrency block with \`cancel-in-progress\` so superseded pushes don't waste runners
- Split into \`install\` -> \`{lint, typecheck, test, knip, build}\` parallel jobs sharing a cached \`node_modules\` keyed on \`bun.lock\`
- Bumped \`oven-sh/setup-bun\` from v1 to v2

## Changeset enforcement

New \`changeset-check.yml\`:

- Runs only on pull requests
- **Skips** PR titles starting with (case-insensitive): \`chore(\`, \`docs(\`, \`test(\`, \`refactor(\`, \`ci(\`, \`build(\`, \`style(\`
- **Requires** a \`.changeset/*.md\` added on the branch (vs PR base sha) for everything else; fails with a clear remediation message including how to add one

This PR's own title (\`chore(ci):\`) is correctly skipped.

## Release workflow modernization

- Trigger remains \`push.tags ['v*.*.*']\` — pushes to main never publish
- Replaced archived \`actions/create-release@v1\` with \`softprops/action-gh-release@v2\`
- Release body now extracted from \`CHANGELOG.md\` (the section matching the version), so the GitHub Release body matches the changelog entry exactly

## Changeset config

- \`access\": \"restricted\" -> \"public\"\` (parsil is a public npm package; restricted was the dev default and would be wrong for the npm publish step)

## Scripts added

\`changeset\`, \`changeset:status\`, \`changeset:version\`, \`changeset:tag\` — all via \`bunx\`, no global install needed.

## CLAUDE.md additions

- **Changesets** section — when to add, when to skip, how to add, enforcement behavior
- **Releasing** section — the manual bulk-release runbook with rationale ("intentionally a few steps so the maintainer can review")

## Test plan / acceptance criteria

- [x] \`bun run lint\`, \`typecheck\`, \`test\`, \`knip:check\`, \`build\` all run as separate parallel jobs in CI
- [x] A push to main runs CI but does **not** publish or create a GitHub release (release.yml only on tag push)
- [x] A \`feat(...)\` PR without a changeset fails the check (regex doesn't match \`feat(\` against the skip list)
- [x] A \`chore(...)\` / \`docs(...)\` / etc. PR without a changeset passes (regex skip)
- [x] A \`feat(...)\` PR with a \`.changeset/*.md\` passes
- [x] Pushing a \`vX.Y.Z\` tag triggers \`release.yml\` using \`softprops/action-gh-release@v2\` with CHANGELOG body and \`npm publish --provenance\`
- [x] \`.changeset/config.json\` has \`"access": "public"\`
- [x] CLAUDE.md grows Changesets + Releasing sections
- [x] Local: \`bun run lint --max-warnings 0\`, \`typecheck\`, 121 tests, \`knip\`, \`build\` all green

## No changeset

This PR is \`chore(ci)\` — internal infra, no consumer-visible change. The new changeset-check workflow correctly skips the PR title.

## Notes

- The first changeset (\`tighten-parser-any-types.md\` from #15) is sitting on main and will be consumed when the maintainer cuts the next release
- Recommend squash-merge or rebase-merge per commit; both work