### PR TITLE
feat(parsers/chain): add chainl1 and chainr1 combinators

### DIFF
--- a/.changeset/precedence-chain-combinators.md
+++ b/.changeset/precedence-chain-combinators.md
@@ -1,0 +1,18 @@
+---
+'parsil': minor
+---
+
+Add `chainl1` and `chainr1` combinators for operator-precedence parsing.
+
+`chainl1(operand, op)` parses one or more operands separated by `op` and folds left-to-right — use for left-associative binary operators (subtraction, division, function application). `chainr1` is the right-fold variant for right-associative operators (exponentiation, cons).
+
+`op` is a parser yielding the binary function combining two operand results (`Parser<(left: T, right: T) => T>`). A trailing operator without a following operand is treated as a parse error, not a soft cut.
+
+```ts
+const num = digits.map(Number)
+const sub = char('-').map(() => (a, b) => a - b)
+chainl1(num, sub).run('1-2-3') // (1 - 2) - 3 = -4
+
+const pow = char('^').map(() => (a, b) => a ** b)
+chainr1(num, pow).run('2^3^2') // 2 ^ (3 ^ 2) = 512
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,11 @@ Don't paraphrase the criteria. Don't merge them in your head. Walk the list as t
 
 - **Public API impact** — `.d.ts` diff against `main` inspected if the change touches public types. No `any` leaks; tightened generics documented.
 - **Downstream consumers** — if parsil's API contract changes, check known consumers (Gero asm parser at `/Users/max/dev/gero_2.0/packages/asm/src/parser/`) and call out adjustments in the PR description.
-- **Docs** — README's API section updated for new public combinators. CLAUDE.md updated for new conventions.
+- **Docs — every doc-affecting change must propagate everywhere it appears**. Concretely:
+  - New public export (parser, combinator, helper, type) → README's **API → Combinators / Core primitives / Methods** section MUST list it. If the README quotes a list of exports, your PR adds yours to that list.
+  - New convention or workflow (commit policy, branch policy, release flow) → CLAUDE.md.
+  - JSDoc on the export itself, of course.
+  - The doc check is **not** "does my code work"; it's "would a reader of the README know my export exists". If no, README is stale and the PR is incomplete.
 - **Type tests** — when the change tightens generic constraints, add a compile-time assertion under `tests/parser/types.spec.ts` so a regression fails CI.
 - **Changeset** — added at the appropriate level (patch/minor/major) for `feat`/`fix`/`perf`/breaking PRs. Skipped only for `chore`/`docs`/`test`/`refactor` (internal-only)/`ci`/`build`/`style`. When in doubt, add one.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Parsil exposes a `Parser<T>` type and a set of combinators. Everything below is 
 - **`exactly(n)(p)`** – repeat parser `n` times
 - **`between(left, right)(value)`** – parse `value` between `left` and `right`
 - **`sepBy(sep)(value)`** / **`sepByOne(sep)(value)`** – separated lists
+- **`chainl1(operand, op)`** / **`chainr1(operand, op)`** – left/right-associative operator-precedence parsing (`op` yields the binary fn)
 - **`possibly(p)`** – optional (returns `null` when absent)
 - **`lookAhead(p)`**, **`peek`**, **`startOfInput`**, **`endOfInput`**
 - **`recursive(thunk)`** – define mutually recursive parsers

--- a/src/parsers/chain/chain-l1.ts
+++ b/src/parsers/chain/chain-l1.ts
@@ -1,0 +1,49 @@
+import { Parser, updateResult } from '@parsil/parser'
+
+/**
+ * Parse one or more `operand`s separated by `op`, left-associative.
+ * Returns the result of folding `op` over the operands left-to-right.
+ *
+ * Use this for binary operators that group to the left, like
+ * subtraction, division, or function application.
+ *
+ * If `op` succeeds but the following `operand` fails, the whole parser
+ * fails — a trailing operator without an operand is treated as
+ * malformed input, not a soft cut.
+ *
+ * @example
+ * const num = digits.map(Number)
+ * const sub = char('-').map(() => (a: number, b: number) => a - b)
+ * const expr = chainl1(num, sub)
+ * expr.run('1-2-3')  // (1 - 2) - 3 = -4
+ *
+ * @param operand Parser for the operands.
+ * @param op Parser that yields a binary function combining two operands.
+ * @returns A parser that succeeds with the left-folded result.
+ */
+export const chainl1 = <T>(
+  operand: Parser<T>,
+  op: Parser<(left: T, right: T) => T>
+): Parser<T> =>
+  new Parser<T>((state) => {
+    if (state.isError) return state
+
+    const firstState = operand.p(state)
+    if (firstState.isError) return firstState
+
+    let acc: T = firstState.result
+    let cursor = firstState
+
+    while (true) {
+      const opState = op.p(cursor)
+      if (opState.isError) break
+
+      const rightState = operand.p(opState)
+      if (rightState.isError) return rightState
+
+      acc = opState.result(acc, rightState.result)
+      cursor = updateResult(rightState, acc)
+    }
+
+    return updateResult(cursor, acc)
+  })

--- a/src/parsers/chain/chain-r1.ts
+++ b/src/parsers/chain/chain-r1.ts
@@ -1,0 +1,57 @@
+import { Parser, updateResult } from '@parsil/parser'
+
+/**
+ * Parse one or more `operand`s separated by `op`, right-associative.
+ * Returns the result of folding `op` over the operands right-to-left.
+ *
+ * Use this for binary operators that group to the right, like
+ * exponentiation in mathematics or the cons operator in many
+ * functional languages.
+ *
+ * If `op` succeeds but the following `operand` fails, the whole parser
+ * fails — a trailing operator without an operand is treated as
+ * malformed input, not a soft cut.
+ *
+ * @example
+ * const num = digits.map(Number)
+ * const pow = char('^').map(() => (a: number, b: number) => a ** b)
+ * const expr = chainr1(num, pow)
+ * expr.run('2^3^2')  // 2 ^ (3 ^ 2) = 2 ^ 9 = 512
+ *
+ * @param operand Parser for the operands.
+ * @param op Parser that yields a binary function combining two operands.
+ * @returns A parser that succeeds with the right-folded result.
+ */
+export const chainr1 = <T>(
+  operand: Parser<T>,
+  op: Parser<(left: T, right: T) => T>
+): Parser<T> =>
+  new Parser<T>((state) => {
+    if (state.isError) return state
+
+    const firstState = operand.p(state)
+    if (firstState.isError) return firstState
+
+    const operands: T[] = [firstState.result]
+    const fns: Array<(left: T, right: T) => T> = []
+    let cursor = firstState
+
+    while (true) {
+      const opState = op.p(cursor)
+      if (opState.isError) break
+
+      const rightState = operand.p(opState)
+      if (rightState.isError) return rightState
+
+      fns.push(opState.result)
+      operands.push(rightState.result)
+      cursor = rightState
+    }
+
+    let result: T = operands[operands.length - 1]
+    for (let i = fns.length - 1; i >= 0; i--) {
+      result = fns[i](operands[i], result)
+    }
+
+    return updateResult(cursor, result)
+  })

--- a/src/parsers/chain/index.ts
+++ b/src/parsers/chain/index.ts
@@ -1,0 +1,2 @@
+export * from '@parsil/parsers/chain/chain-l1'
+export * from '@parsil/parsers/chain/chain-r1'

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,5 +1,6 @@
 export * from '@parsil/parsers/between'
 export * from '@parsil/parsers/bit'
+export * from '@parsil/parsers/chain'
 export * from '@parsil/parsers/char'
 export * from '@parsil/parsers/choice'
 export * from '@parsil/parsers/coroutine'

--- a/tests/parsers/chain/chain-l1.spec.ts
+++ b/tests/parsers/chain/chain-l1.spec.ts
@@ -1,0 +1,81 @@
+import { chainl1, char, choice, digits, possibly } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+const num = digits.map((s) => Number(s))
+
+const sub = char('-').map(() => (a: number, b: number) => a - b)
+const add = char('+').map(() => (a: number, b: number) => a + b)
+const mul = char('*').map(() => (a: number, b: number) => a * b)
+const addOrSub = choice([add, sub])
+
+describe('chainl1', () => {
+  it('returns the operand alone when no operator follows', () => {
+    const expr = chainl1(num, sub)
+    const result = expr.run('42')
+
+    assertIsOk(result)
+    expect(result.result).toBe(42)
+  })
+
+  it('folds left over a non-associative operator', () => {
+    // Subtraction is non-associative, so the fold direction is observable.
+    // Left-fold of `1-2-3` = (1 - 2) - 3 = -4 (would be 2 if right-folded)
+    const expr = chainl1(num, sub)
+    const result = expr.run('1-2-3')
+
+    assertIsOk(result)
+    expect(result.result).toBe(-4)
+  })
+
+  it('mixes operators that share a precedence level', () => {
+    const expr = chainl1(num, addOrSub)
+    const result = expr.run('10+5-3+1')
+
+    assertIsOk(result)
+    expect(result.result).toBe(13)
+  })
+
+  it('layers with itself to express precedence', () => {
+    // term = num (* num)*           — higher precedence, binds tighter
+    // expr = term ((+|-) term)*
+    const term = chainl1(num, mul)
+    const expr = chainl1(term, addOrSub)
+
+    const result = expr.run('2+3*4-1')
+    assertIsOk(result)
+    // 2 + (3 * 4) - 1 = 13
+    expect(result.result).toBe(13)
+  })
+
+  it('fails when the first operand fails', () => {
+    const expr = chainl1(num, sub)
+    const result = expr.run('xyz')
+
+    assertIsError(result)
+  })
+
+  it('fails when an operator is followed by no operand', () => {
+    const expr = chainl1(num, sub)
+    const result = expr.run('1-2-')
+
+    // Trailing '-' starts an op that succeeds, but the operand after
+    // it is missing → the chain fails rather than soft-cutting.
+    assertIsError(result)
+  })
+
+  it('stops at a non-operator character and leaves the cursor positioned for the next parser', () => {
+    const expr = chainl1(num, sub)
+    const trailing = possibly(char(';'))
+
+    const result = expr.run('1-2;')
+    assertIsOk(result)
+    expect(result.result).toBe(-1)
+    // index should land on ';' so a subsequent parser can resume cleanly
+    expect(result.index).toBe(3)
+
+    const tailResult = trailing.run('1-2;'.slice(3))
+    assertIsOk(tailResult)
+  })
+})

--- a/tests/parsers/chain/chain-r1.spec.ts
+++ b/tests/parsers/chain/chain-r1.spec.ts
@@ -1,0 +1,72 @@
+import { chainr1, char, digits } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+const num = digits.map((s) => Number(s))
+
+const pow = char('^').map(() => (a: number, b: number) => a ** b)
+
+describe('chainr1', () => {
+  it('returns the operand alone when no operator follows', () => {
+    const expr = chainr1(num, pow)
+    const result = expr.run('5')
+
+    assertIsOk(result)
+    expect(result.result).toBe(5)
+  })
+
+  it('folds right over a non-associative operator', () => {
+    // 2 ^ (3 ^ 2) = 2 ^ 9 = 512
+    // (would be 64 = 8^2 if left-folded)
+    const expr = chainr1(num, pow)
+    const result = expr.run('2^3^2')
+
+    assertIsOk(result)
+    expect(result.result).toBe(512)
+  })
+
+  it('handles a longer right-fold', () => {
+    // 2 ^ (2 ^ (2 ^ 2)) = 2 ^ (2 ^ 4) = 2 ^ 16 = 65536
+    const expr = chainr1(num, pow)
+    const result = expr.run('2^2^2^2')
+
+    assertIsOk(result)
+    expect(result.result).toBe(65536)
+  })
+
+  it('demonstrates right-association concretely with an asymmetric operator', () => {
+    // append: (a, b) => a*10 + b
+    // Right-fold of [1, 2, 3] = (1, (2, 3)) = (1, 23) = 1*10 + 23 = 33
+    // Left-fold would be ((1, 2), 3) = (12, 3) = 12*10 + 3 = 123
+    const append = char(':').map(() => (a: number, b: number) => a * 10 + b)
+    const expr = chainr1(num, append)
+    const result = expr.run('1:2:3')
+
+    assertIsOk(result)
+    expect(result.result).toBe(33)
+  })
+
+  it('fails when the first operand fails', () => {
+    const expr = chainr1(num, pow)
+    const result = expr.run('xyz')
+
+    assertIsError(result)
+  })
+
+  it('fails when an operator is followed by no operand', () => {
+    const expr = chainr1(num, pow)
+    const result = expr.run('2^3^')
+
+    assertIsError(result)
+  })
+
+  it('does not consume a trailing non-operator', () => {
+    const expr = chainr1(num, pow)
+    const result = expr.run('2^3 rest')
+
+    assertIsOk(result)
+    expect(result.result).toBe(8)
+    expect(result.index).toBe(3)
+  })
+})


### PR DESCRIPTION
Closes #7.

## Summary

Left- and right-associative operator-precedence combinators. Removes the boilerplate of \`manyOne(sequenceOf([op, term]))\` + manual reduce that any expression-heavy grammar (GTX, future calculator examples, Gero asm address expressions) ends up writing.

## API

\`\`\`ts
chainl1<T>(operand: Parser<T>, op: Parser<(l: T, r: T) => T>): Parser<T>
chainr1<T>(operand: Parser<T>, op: Parser<(l: T, r: T) => T>): Parser<T>
\`\`\`

The \`op\` parser yields the binary function combining two operand results. A trailing operator without a following operand is treated as a parse error rather than a soft cut — matches Parsec convention.

## Tests (14 new, all green)

\`chain-l1.spec.ts\`:
- Returns operand alone when no op follows
- Left-fold over \`-\` (\`1-2-3\` -> -4)
- Mixed precedence-level ops (\`+\`/\`-\`)
- Precedence layering with another chainl1 (\`*\` tighter than \`+\`/\`-\`)
- Failure on first-operand failure
- Failure on \`op\` without following operand
- Cursor positioned correctly at trailing non-op

\`chain-r1.spec.ts\`:
- Returns operand alone when no op follows
- Right-fold over \`^\` (\`2^3^2\` -> 512)
- Longer right-fold (\`2^2^2^2\` -> 65536)
- Asymmetric op confirming fold direction
- Failure on first-operand failure
- Failure on \`op\` without following operand
- Cursor positioned correctly at trailing non-op

## Acceptance criteria from #7

- [x] Tests pass (135 total / 0 fail / 234 expects across 41 files)
- [x] README **API → Combinators** section updated with \`chainl1\` / \`chainr1\`
- [x] No new runtime deps

Plus the strengthened self-review checks:
- [x] Lint clean with \`--max-warnings 0\`
- [x] Typecheck clean
- [x] Knip clean
- [x] Build clean (12.94 KB ESM)
- [x] Changeset added (\`minor\` — new public exports)

## Notes

This is the first \`feat\` PR landing under the new changeset enforcement workflow (#16). The \`changeset-check\` job should pass since \`.changeset/precedence-chain-combinators.md\` is added on the branch.