### PR TITLE
test(parsers/char): pin UTF-8 correctness of everyCharUntil

### DIFF
--- a/src/parsers/char/every-char-until.ts
+++ b/src/parsers/char/every-char-until.ts
@@ -3,17 +3,28 @@ import { everythingUntil } from '@parsil/parsers/everything-until'
 import { decoder } from '@parsil/util'
 
 /**
- * `everyCharUntil` is a higher order parser that parses an input stream until a specific condition, defined by another parser, is met.
- * Unlike `everythingUntil`, this parser converts the collected bytes to a string using a `TextDecoder`.
+ * `everyCharUntil` is a higher-order parser that consumes the input until
+ * the provided `parser` would succeed at the current position, then
+ * returns everything before that point as a UTF-8 string.
+ *
+ * Unlike `everythingUntil` (which returns the raw byte values), this
+ * parser decodes the collected bytes via `TextDecoder`.
+ *
+ * UTF-8 correctness note: the underlying byte-by-byte walk is safe even
+ * for inputs containing multi-byte chars. UTF-8 is self-synchronizing —
+ * continuation bytes (0x80-0xBF) cannot be confused with start bytes or
+ * with ASCII (0x00-0x7F), so a marker like `str('é')` ([0xC3, 0xA9]) only
+ * matches at a true char boundary, and `decoder.decode` reassembles the
+ * collected bytes into a valid UTF-8 string. The full test matrix lives
+ * in `tests/parsers/char/every-char-until.spec.ts`.
  *
  * @example
- * const parser = everyCharUntil(str("end"));
- * parser.run("123end456");  // returns "123"
- * parser.run("Hello World");  // returns "Hello World", as "end" is not found
+ * everyCharUntil(str('end')).run('123end456') // '123'
+ * everyCharUntil(str(',')).run('日本語,foo')     // '日本語'
  *
- * @param parser - A parser that defines the condition for the end of parsing.
- *
- * @returns A parser that consumes the input until the parser parameter returns a successful state.
+ * @param parser A parser that defines the condition for the end of consumption.
+ * @returns A parser that consumes input until `parser` would succeed and
+ *   returns the consumed prefix as a string.
  */
 export const everyCharUntil = <T>(parser: Parser<T>) =>
   everythingUntil(parser).map((results) =>

--- a/tests/parsers/char/every-char-until.spec.ts
+++ b/tests/parsers/char/every-char-until.spec.ts
@@ -42,4 +42,66 @@ describe('everyCharUntil', () => {
       index: 3,
     })
   })
+
+  // The audit (#25) initially flagged byte-by-byte indexing as a UTF-8 hazard.
+  // Investigation showed the implementation is correct for valid string
+  // inputs because UTF-8 is self-synchronizing: continuation bytes
+  // (0x80-0xBF) cannot be confused with start bytes or with ASCII (0x00-0x7F).
+  // A marker like `str('é')` ([0xC3, 0xA9]) only matches at a true char
+  // boundary, and `decoder.decode` reassembles the collected bytes into a
+  // valid UTF-8 string. These tests pin that correctness so it can't
+  // regress when #30 (everythingUntil/everyCharUntil semantic refonte) lands.
+  describe('UTF-8 correctness on multi-byte chars', () => {
+    it('preserves a 2-byte char in the prefix (ASCII marker)', () => {
+      const parser = everyCharUntil(str('end'))
+      const result = parser.run('héllo end')
+
+      assertIsOk(result)
+      expect(result.result).toBe('héllo ')
+      // "héllo " = h(1) é(2) l(1) l(1) o(1) ' '(1) = 7 bytes
+      expect(result.index).toBe(7)
+    })
+
+    it('preserves a 3-byte char (CJK) in the prefix', () => {
+      const parser = everyCharUntil(str(','))
+      const result = parser.run('日本語,foo')
+
+      assertIsOk(result)
+      expect(result.result).toBe('日本語')
+      // '日本語' = 3 chars × 3 bytes each = 9 bytes
+      expect(result.index).toBe(9)
+    })
+
+    it('handles a non-ASCII marker correctly', () => {
+      const parser = everyCharUntil(str('€'))
+      const result = parser.run('hé€llo')
+
+      assertIsOk(result)
+      expect(result.result).toBe('hé')
+      // "hé" = h(1) é(2) = 3 bytes; '€' starts at byte 3
+      expect(result.index).toBe(3)
+    })
+
+    it('handles a multi-byte marker after consecutive multi-byte chars', () => {
+      const parser = everyCharUntil(str('!'))
+      const result = parser.run('αβγ!δε')
+
+      assertIsOk(result)
+      expect(result.result).toBe('αβγ')
+      // 'αβγ' = 3 chars × 2 bytes each = 6 bytes
+      expect(result.index).toBe(6)
+    })
+
+    it('matches a multi-byte marker only at a true char boundary', () => {
+      // The marker 'é' is bytes [0xC3, 0xA9]. UTF-8 self-sync guarantees
+      // these bytes cannot appear inside another char's encoding, so the
+      // match always lands cleanly.
+      const parser = everyCharUntil(str('é'))
+      const result = parser.run('hellé world')
+
+      assertIsOk(result)
+      expect(result.result).toBe('hell')
+      expect(result.index).toBe(4)
+    })
+  })
 })


### PR DESCRIPTION
Closes #25.

## Note: bug as originally described does not reproduce

The issue flagged \`everyCharUntil\` as broken on multi-byte UTF-8 inputs because it walks bytes via \`everythingUntil\` and decodes the full buffer at the end.

After reproduction attempts on every adversarial case I could think of:

| Input | Marker | Expected | Got |
| --- | --- | --- | --- |
| \`'héllo end'\` | \`'end'\` | \`'héllo '\` | \`'héllo '\` ✅ |
| \`'日本語,foo'\` | \`','\` | \`'日本語'\` | \`'日本語'\` ✅ |
| \`'hé€llo'\` | \`'€'\` | \`'hé'\` | \`'hé'\` ✅ |
| \`'αβγ!δε'\` | \`'!'\` | \`'αβγ'\` | \`'αβγ'\` ✅ |
| \`'hellé world'\` | \`'é'\` | \`'hell'\` | \`'hell'\` ✅ |

**Why it works**: UTF-8 is **self-synchronizing**. Continuation bytes (\`0x80–0xBF\`) cannot be confused with start bytes or with ASCII (\`0x00–0x7F\`). A marker like \`str('é')\` ([\`0xC3\`, \`0xA9\`]) only matches at a true char boundary, and \`decoder.decode\` reassembles the collected bytes into valid UTF-8.

The audit's claim was wrong on this specific point. Honest correction.

## What this PR does

- **5 regression tests** covering the multi-byte cases from the table above. Pin the current correct behavior so the semantic refonte in #30 cannot regress it.
- **JSDoc on \`everyCharUntil\`** rewritten to document the byte-walk + UTF-8 self-sync explicitly, so future contributors don't 'optimize' the byte-walking and accidentally introduce a bug.

## Acceptance criteria from #25

- [x] **Regression tests cover the multi-byte case** — 5 added.
- [x] **\`everyCharUntil(str('end'))\` on \`'héllo end'\` returns \`'héllo '\`** — verified (was already correct, now pinned).
- [x] **\`everythingUntil\` on a binary buffer with a marker still works byte-level (no regression)** — existing tests still pass.
- [x] **All existing tests pass** — 147/147 (was 142, +5 new).
- [~] **Changeset: patch** — **deviated**: no changeset because there's no behavior change to ship. The PR is \`test\` + \`docs\` scope. Per the changeset policy, no entry needed.

## Test plan

- [x] \`bun run lint\` clean with \`--max-warnings 0\`
- [x] \`bun run typecheck\` clean
- [x] \`bun test\` — 147 pass / 0 fail
- [x] \`bun run knip:check\` clean
- [x] \`bun run build\` clean

## Sequencing

The architectural unification of \`everythingUntil\` / \`everyCharUntil\` (one shared driver, explicit byte-vs-char split) lives in #30, which is also tagged for v3.0.0. The tests added here will guard #30's refactor.