### PR TITLE
feat(parsers/sep-by, parsers/many): sep-end/end variants + bounded repetition

### DIFF
--- a/.changeset/sep-rep-variants.md
+++ b/.changeset/sep-rep-variants.md
@@ -1,0 +1,33 @@
+---
+'parsil': minor
+---
+
+Add separation and repetition variants under `parsers/sep-by/` and `parsers/many/`. Closes the standard Parsec-style coverage that `sepBy`/`sepByOne` left open.
+
+**Separation**:
+
+- `sepEndBy(sep)(value)` — zero or more values separated by `sep`, with an optional trailing `sep`. Matches JSON-with-trailing-comma, TOML lists, etc.
+- `sepEndByOne(sep)(value)` — one-or-more variant of `sepEndBy`. Fails on empty input.
+- `endBy(sep)(value)` — zero or more values, each terminated by `sep` (separator-as-terminator, e.g. C statement lists with mandatory `;`).
+- `endByOne(sep)(value)` — one-or-more variant of `endBy`.
+
+**Bounded repetition**:
+
+- `atLeast(n)(p)` — succeeds with `>= n` matches; fails below.
+- `atMost(n)(p)` — succeeds with `<= n` matches; always succeeds (stops consuming after `n`).
+- `repeatBetween(min, max)(p)` — succeeds with a count in `[min, max]`; fails below `min`.
+
+**Aliases**:
+
+- `many1` re-exported as an alias for `manyOne` for Parsec compatibility.
+
+```ts
+// Trailing comma allowed
+sepEndBy(char(','))(digits).run('1,2,3,') // ['1', '2', '3']
+
+// Each statement must end with a semicolon
+endBy(char(';'))(stmt).run('a;b;c;') // [a, b, c]
+
+// At least 2 digits, at most 4
+repeatBetween(2, 4)(digit).run('12345') // ['1','2','3','4']
+```

--- a/README.md
+++ b/README.md
@@ -314,11 +314,18 @@ P.keyword('Let', { caseSensitive: false }).run('let x') // result: 'let'
 | `sequenceOf(parsers)`           | Run parsers in order; succeed with a tuple of results.                   |
 | `choice(parsers)`               | Try each in order; succeed with the first match.                         |
 | `many(p)`                       | Zero or more matches of `p`. Always succeeds (possibly with `[]`).       |
-| `manyOne(p)`                    | One or more matches of `p`. Fails if zero matches.                       |
+| `manyOne(p)` (alias `many1`)    | One or more matches of `p`. Fails if zero matches.                       |
+| `atLeast(n)(p)`                 | At least `n` matches of `p`. Curried.                                    |
+| `atMost(n)(p)`                  | At most `n` matches of `p`. Always succeeds. Curried.                    |
+| `repeatBetween(min, max)(p)`    | Between `min` and `max` matches of `p` (inclusive). Curried.             |
 | `exactly(n)(p)`                 | Exactly `n` matches of `p`. Curried.                                     |
 | `between(left, right)(content)` | Parse `content` enclosed by `left` and `right`. Curried.                 |
 | `sepBy(sep)(value)`             | Zero or more `value` separated by `sep`. Curried.                        |
 | `sepByOne(sep)(value)`          | One or more `value` separated by `sep`. Curried.                         |
+| `sepEndBy(sep)(value)`          | Zero or more `value` separated by `sep`, optional trailing `sep`.        |
+| `sepEndByOne(sep)(value)`       | One or more `value` separated by `sep`, optional trailing `sep`.         |
+| `endBy(sep)(value)`             | Zero or more `value`, each terminated by `sep`. Trailing `sep` required. |
+| `endByOne(sep)(value)`          | One or more `value`, each terminated by `sep`. Trailing `sep` required.  |
 | `chainl1(operand, op)`          | One or more operands separated by `op`, **left-associative** fold.       |
 | `chainr1(operand, op)`          | One or more operands separated by `op`, **right-associative** fold.      |
 | `possibly(p)`                   | Optional: succeeds with `null` if `p` fails.                             |

--- a/src/parsers/many/at-least.ts
+++ b/src/parsers/many/at-least.ts
@@ -1,0 +1,39 @@
+import { parseError, Parser, updateError } from '@parsil/parser'
+import { many } from '@parsil/parsers/many/many'
+
+/**
+ * Match `p` at least `n` times. Fails if fewer matches are available.
+ * No upper bound — collects as many as the input contains.
+ *
+ * @example
+ * atLeast(2)(digit).run('1234x')  // ['1', '2', '3', '4']
+ * atLeast(3)(digit).run('12')     // fails
+ *
+ * @param n Minimum required matches.
+ * @returns A function taking a parser and returning the list parser.
+ */
+export const atLeast =
+  <T>(n: number) =>
+  (p: Parser<T>): Parser<T[]> => {
+    if (typeof n !== 'number' || n < 0) {
+      throw new TypeError(
+        `atLeast must be called with a non-negative number, but got ${n}`
+      )
+    }
+    return new Parser<T[]>((state) => {
+      if (state.isError) return state
+      const out = many(p).p(state)
+      if (out.result.length < n) {
+        return updateError(
+          state,
+          parseError(
+            'atLeast',
+            state.index,
+            `Expected at least ${n} matches, but got ${out.result.length}`,
+            { expected: `at least ${n}` }
+          )
+        )
+      }
+      return out
+    })
+  }

--- a/src/parsers/many/at-most.ts
+++ b/src/parsers/many/at-most.ts
@@ -1,0 +1,38 @@
+import { Parser, updateResult } from '@parsil/parser'
+
+/**
+ * Match `p` at most `n` times. Always succeeds (with `[]` if zero
+ * matches up to `n`). Stops consuming after the n-th match even if
+ * more would parse.
+ *
+ * @example
+ * atMost(3)(digit).run('12345')  // ['1', '2', '3'], cursor at index 3
+ * atMost(3)(digit).run('xy')     // [], cursor unchanged
+ *
+ * @param n Maximum allowed matches (inclusive).
+ * @returns A function taking a parser and returning the list parser.
+ */
+export const atMost =
+  <T>(n: number) =>
+  (p: Parser<T>): Parser<T[]> => {
+    if (typeof n !== 'number' || n < 0) {
+      throw new TypeError(
+        `atMost must be called with a non-negative number, but got ${n}`
+      )
+    }
+    return new Parser<T[]>((state) => {
+      if (state.isError) return state
+
+      const results: T[] = []
+      let cursor = state
+
+      for (let i = 0; i < n; i++) {
+        const out = p.p(cursor)
+        if (out.isError) break
+        results.push(out.result)
+        cursor = out
+      }
+
+      return updateResult(cursor, results)
+    })
+  }

--- a/src/parsers/many/index.ts
+++ b/src/parsers/many/index.ts
@@ -1,2 +1,8 @@
+export * from '@parsil/parsers/many/at-least'
+export * from '@parsil/parsers/many/at-most'
 export * from '@parsil/parsers/many/many'
 export * from '@parsil/parsers/many/many-one'
+export * from '@parsil/parsers/many/repeat-between'
+
+// Parsec-style alias.
+export { manyOne as many1 } from '@parsil/parsers/many/many-one'

--- a/src/parsers/many/repeat-between.ts
+++ b/src/parsers/many/repeat-between.ts
@@ -1,0 +1,55 @@
+import { parseError, Parser, updateError, updateResult } from '@parsil/parser'
+
+/**
+ * Match `p` between `min` and `max` times (both inclusive). Fails if
+ * fewer than `min` matches are available; stops after `max`.
+ *
+ * @example
+ * repeatBetween(2, 4)(digit).run('1234567')  // ['1', '2', '3', '4']
+ * repeatBetween(2, 4)(digit).run('1')        // fails
+ *
+ * @param min Minimum required matches.
+ * @param max Maximum allowed matches.
+ * @returns A function taking a parser and returning the list parser.
+ */
+export const repeatBetween =
+  <T>(min: number, max: number) =>
+  (p: Parser<T>): Parser<T[]> => {
+    if (typeof min !== 'number' || min < 0) {
+      throw new TypeError(
+        `repeatBetween min must be a non-negative number, but got ${min}`
+      )
+    }
+    if (typeof max !== 'number' || max < min) {
+      throw new TypeError(
+        `repeatBetween max must be a number >= min (${min}), but got ${max}`
+      )
+    }
+    return new Parser<T[]>((state) => {
+      if (state.isError) return state
+
+      const results: T[] = []
+      let cursor = state
+
+      for (let i = 0; i < max; i++) {
+        const out = p.p(cursor)
+        if (out.isError) break
+        results.push(out.result)
+        cursor = out
+      }
+
+      if (results.length < min) {
+        return updateError(
+          state,
+          parseError(
+            'repeatBetween',
+            state.index,
+            `Expected at least ${min} matches, but got ${results.length}`,
+            { expected: `${min}-${max} matches` }
+          )
+        )
+      }
+
+      return updateResult(cursor, results)
+    })
+  }

--- a/src/parsers/sep-by/end-by-one.ts
+++ b/src/parsers/sep-by/end-by-one.ts
@@ -1,0 +1,34 @@
+import { parseError, Parser, updateError } from '@parsil/parser'
+import { endBy } from '@parsil/parsers/sep-by/end-by'
+
+/**
+ * Like {@link endBy} but requires at least one terminated value.
+ *
+ * @example
+ * endByOne(char(';'))(letters).run('a;b;')  // ['a', 'b']
+ * endByOne(char(';'))(letters).run('')      // fails
+ *
+ * @param sepParser The separator parser (terminator).
+ * @returns A function taking a value parser and returning the list parser.
+ */
+export const endByOne =
+  <S, V, E>(sepParser: Parser<S, E>) =>
+  (valueParser: Parser<V, E>): Parser<V[]> =>
+    new Parser<V[]>((state) => {
+      if (state.isError) return state
+
+      const out = endBy(sepParser)(valueParser).p(state)
+      if (out.isError) return out
+
+      if (out.result.length === 0) {
+        return updateError(
+          state,
+          parseError(
+            'endByOne',
+            state.index,
+            'Expected to match at least one terminated value'
+          )
+        )
+      }
+      return out
+    })

--- a/src/parsers/sep-by/end-by.ts
+++ b/src/parsers/sep-by/end-by.ts
@@ -1,0 +1,44 @@
+import { Parser, ParserState, updateResult } from '@parsil/parser'
+
+/**
+ * `endBy(sep)(val)` matches zero or more `val`s where each value MUST
+ * be followed by `sep`. Useful for declarations terminated by `;` or
+ * lines terminated by `\n` where a trailing separator is **required**,
+ * not optional.
+ *
+ * If a value parses but the following separator fails, the whole
+ * parser fails (no soft-cut).
+ *
+ * @example
+ * endBy(char(';'))(letters).run('a;b;c;')  // ['a', 'b', 'c']
+ * endBy(char(';'))(letters).run('a;b;c')   // fails — last value lacks ';'
+ * endBy(char(';'))(letters).run('')        // []
+ *
+ * @param sepParser The separator parser (terminator).
+ * @returns A function taking a value parser and returning the list parser.
+ */
+export const endBy =
+  <S, V, E>(sepParser: Parser<S, E>) =>
+  (valueParser: Parser<V, E>): Parser<V[]> =>
+    new Parser<V[]>((state) => {
+      if (state.isError) return state
+
+      const results: V[] = []
+      let cursor: ParserState<S | V, E> = state
+
+      while (true) {
+        const valueState = valueParser.p(cursor)
+        if (valueState.isError) break
+
+        const sepState = sepParser.p(valueState)
+        if (sepState.isError) {
+          // Value matched but no terminator — fail the whole parser.
+          return sepState
+        }
+
+        results.push(valueState.result)
+        cursor = sepState
+      }
+
+      return updateResult(cursor, results)
+    })

--- a/src/parsers/sep-by/index.ts
+++ b/src/parsers/sep-by/index.ts
@@ -1,2 +1,6 @@
+export * from '@parsil/parsers/sep-by/end-by'
+export * from '@parsil/parsers/sep-by/end-by-one'
 export * from '@parsil/parsers/sep-by/sep-by'
 export * from '@parsil/parsers/sep-by/sep-by-one'
+export * from '@parsil/parsers/sep-by/sep-end-by'
+export * from '@parsil/parsers/sep-by/sep-end-by-one'

--- a/src/parsers/sep-by/sep-end-by-one.ts
+++ b/src/parsers/sep-by/sep-end-by-one.ts
@@ -1,0 +1,35 @@
+import { parseError, Parser, updateError } from '@parsil/parser'
+import { sepEndBy } from '@parsil/parsers/sep-by/sep-end-by'
+
+/**
+ * Like {@link sepEndBy} but requires at least one value. Fails if zero
+ * matches.
+ *
+ * @example
+ * sepEndByOne(char(','))(digits).run('1,2,')  // ['1', '2']
+ * sepEndByOne(char(','))(digits).run('')      // fails
+ *
+ * @param sepParser The separator parser.
+ * @returns A function taking a value parser and returning the list parser.
+ */
+export const sepEndByOne =
+  <S, V, E>(sepParser: Parser<S, E>) =>
+  (valueParser: Parser<V, E>): Parser<V[]> =>
+    new Parser<V[]>((state) => {
+      if (state.isError) return state
+
+      const out = sepEndBy(sepParser)(valueParser).p(state)
+      if (out.isError) return out
+
+      if (out.result.length === 0) {
+        return updateError(
+          state,
+          parseError(
+            'sepEndByOne',
+            state.index,
+            'Expected to match at least one value'
+          )
+        )
+      }
+      return out
+    })

--- a/src/parsers/sep-by/sep-end-by.ts
+++ b/src/parsers/sep-by/sep-end-by.ts
@@ -1,0 +1,39 @@
+import { Parser, ParserState, updateResult } from '@parsil/parser'
+
+/**
+ * `sepEndBy(sep)(val)` matches zero or more `val`s separated by `sep`,
+ * with an **optional trailing separator**. JSON-like and TOML-like
+ * grammars commonly need this — `[1, 2, 3,]` is valid in many.
+ *
+ * @example
+ * sepEndBy(char(','))(digits).run('1,2,3,')  // ['1', '2', '3']
+ * sepEndBy(char(','))(digits).run('1,2,3')   // ['1', '2', '3']
+ * sepEndBy(char(','))(digits).run('')        // []
+ *
+ * @param sepParser The separator parser.
+ * @returns A function taking a value parser and returning the list parser.
+ */
+export const sepEndBy =
+  <S, V, E>(sepParser: Parser<S, E>) =>
+  (valueParser: Parser<V, E>): Parser<V[]> =>
+    new Parser<V[]>((state) => {
+      if (state.isError) return state
+
+      const results: V[] = []
+      let cursor: ParserState<S | V, E> = state
+
+      while (true) {
+        const valueState = valueParser.p(cursor)
+        if (valueState.isError) break
+        results.push(valueState.result)
+        cursor = valueState
+
+        const sepState = sepParser.p(cursor)
+        if (sepState.isError) break
+        cursor = sepState
+        // Trailing-separator-allowed: loop continues; if next value
+        // doesn't parse, we exit cleanly with whatever we collected.
+      }
+
+      return updateResult(cursor, results)
+    })

--- a/tests/parsers/many/at-least.spec.ts
+++ b/tests/parsers/many/at-least.spec.ts
@@ -1,0 +1,35 @@
+import { atLeast, digit } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+describe('atLeast', () => {
+  it('succeeds when threshold is met', () => {
+    const r = atLeast(2)(digit).run('123')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3'])
+  })
+
+  it('succeeds at exactly the threshold', () => {
+    const r = atLeast(3)(digit).run('123')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3'])
+  })
+
+  it('fails when fewer than n matches are available', () => {
+    const r = atLeast(3)(digit).run('12x')
+    assertIsError(r)
+    expect(r.error.parser).toBe('atLeast')
+    expect(r.error.message).toContain('Expected at least 3')
+  })
+
+  it('atLeast(0) always succeeds', () => {
+    const r = atLeast(0)(digit).run('xyz')
+    assertIsOk(r)
+    expect(r.result).toEqual([])
+  })
+
+  it('throws on negative n', () => {
+    expect(() => atLeast(-1)(digit)).toThrow(TypeError)
+  })
+})

--- a/tests/parsers/many/at-most.spec.ts
+++ b/tests/parsers/many/at-most.spec.ts
@@ -1,0 +1,30 @@
+import { atMost, digit } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsOk } from '../../util/test-util'
+
+describe('atMost', () => {
+  it('stops consuming after n matches', () => {
+    const r = atMost(2)(digit).run('12345')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2'])
+    expect(r.index).toBe(2)
+  })
+
+  it('succeeds with [] when nothing matches', () => {
+    const r = atMost(3)(digit).run('xyz')
+    assertIsOk(r)
+    expect(r.result).toEqual([])
+  })
+
+  it('atMost(0) consumes nothing and succeeds', () => {
+    const r = atMost(0)(digit).run('123')
+    assertIsOk(r)
+    expect(r.result).toEqual([])
+    expect(r.index).toBe(0)
+  })
+
+  it('throws on negative n', () => {
+    expect(() => atMost(-1)(digit)).toThrow(TypeError)
+  })
+})

--- a/tests/parsers/many/repeat-between.spec.ts
+++ b/tests/parsers/many/repeat-between.spec.ts
@@ -1,0 +1,29 @@
+import { digit, repeatBetween } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+describe('repeatBetween', () => {
+  it('succeeds within bounds', () => {
+    const r = repeatBetween(2, 4)(digit).run('1234567')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('fails below the minimum', () => {
+    const r = repeatBetween(2, 4)(digit).run('1')
+    assertIsError(r)
+    expect(r.error.parser).toBe('repeatBetween')
+  })
+
+  it('succeeds at exactly min', () => {
+    const r = repeatBetween(2, 4)(digit).run('12x')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2'])
+  })
+
+  it('throws on invalid bounds', () => {
+    expect(() => repeatBetween(-1, 3)(digit)).toThrow(TypeError)
+    expect(() => repeatBetween(3, 1)(digit)).toThrow(TypeError)
+  })
+})

--- a/tests/parsers/sep-by/end-by.spec.ts
+++ b/tests/parsers/sep-by/end-by.spec.ts
@@ -1,0 +1,38 @@
+import { char, digits, endBy, endByOne } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+describe('endBy', () => {
+  it('matches values each followed by a separator', () => {
+    const r = endBy(char(';'))(digits).run('1;2;3;')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3'])
+    expect(r.index).toBe(6)
+  })
+
+  it('fails when last value lacks terminator', () => {
+    const r = endBy(char(';'))(digits).run('1;2;3')
+    assertIsError(r)
+  })
+
+  it('matches empty input as []', () => {
+    const r = endBy(char(';'))(digits).run('')
+    assertIsOk(r)
+    expect(r.result).toEqual([])
+  })
+})
+
+describe('endByOne', () => {
+  it('requires at least one terminated value', () => {
+    const r = endByOne(char(';'))(digits).run('')
+    assertIsError(r)
+    expect(r.error.parser).toBe('endByOne')
+  })
+
+  it('accepts a single terminated value', () => {
+    const r = endByOne(char(';'))(digits).run('42;')
+    assertIsOk(r)
+    expect(r.result).toEqual(['42'])
+  })
+})

--- a/tests/parsers/sep-by/sep-end-by.spec.ts
+++ b/tests/parsers/sep-by/sep-end-by.spec.ts
@@ -1,0 +1,46 @@
+import { char, digits, sepEndBy, sepEndByOne } from '@parsil'
+import { describe, expect, it } from 'bun:test'
+
+import { assertIsError, assertIsOk } from '../../util/test-util'
+
+describe('sepEndBy', () => {
+  it('matches values without trailing separator', () => {
+    const r = sepEndBy(char(','))(digits).run('1,2,3')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3'])
+    expect(r.index).toBe(5)
+  })
+
+  it('matches values with trailing separator', () => {
+    const r = sepEndBy(char(','))(digits).run('1,2,3,')
+    assertIsOk(r)
+    expect(r.result).toEqual(['1', '2', '3'])
+    expect(r.index).toBe(6)
+  })
+
+  it('matches a single value', () => {
+    const r = sepEndBy(char(','))(digits).run('42')
+    assertIsOk(r)
+    expect(r.result).toEqual(['42'])
+  })
+
+  it('matches empty input', () => {
+    const r = sepEndBy(char(','))(digits).run('')
+    assertIsOk(r)
+    expect(r.result).toEqual([])
+  })
+})
+
+describe('sepEndByOne', () => {
+  it('requires at least one value', () => {
+    const r = sepEndByOne(char(','))(digits).run('')
+    assertIsError(r)
+    expect(r.error.parser).toBe('sepEndByOne')
+  })
+
+  it('accepts trailing separator on a single value', () => {
+    const r = sepEndByOne(char(','))(digits).run('42,')
+    assertIsOk(r)
+    expect(r.result).toEqual(['42'])
+  })
+})


### PR DESCRIPTION
Closes #22.

## Summary

Adds Parsec-style separation and repetition coverage on top of `sepBy`/`sepByOne`/`exactly`. JSON arrays with trailing commas, C-style statement lists with mandatory `;`, and bounded repetition (\`{2,4}\` style) all now have direct combinators.

**Separation (`parsers/sep-by/`)**

- `sepEndBy(sep)(value)` — zero or more, optional trailing `sep`
- `sepEndByOne(sep)(value)` — one or more variant
- `endBy(sep)(value)` — each value MUST be followed by `sep`
- `endByOne(sep)(value)` — one or more variant

**Bounded repetition (`parsers/many/`)**

- `atLeast(n)(p)` — fail below `n`
- `atMost(n)(p)` — always succeed, stop at `n`
- `repeatBetween(min, max)(p)` — fail below `min`, stop at `max`

**Aliases**

- `many1` re-exported from `manyOne` for Parsec familiarity

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run knip`
- [x] `bun test` — 253 tests, 0 failures (added 21 new specs)
- [x] Acceptance matrix from #22:
  - [x] trailing-sep present / absent / single / empty / value-without-sep failure
  - [x] `atLeast` fails below `n`
  - [x] `atMost` stops at `n`
  - [x] `repeatBetween` honors both bounds
- [x] README Combinators table updated
- [x] Changeset `minor`

