### PR TITLE
refactor(parsers/everything-until): unify byte vs char on shared driver + mode option

### DIFF
--- a/.changeset/everything-until-refonte.md
+++ b/.changeset/everything-until-refonte.md
@@ -1,0 +1,20 @@
+---
+'parsil': patch
+---
+
+Refactor `everythingUntil` and `everyCharUntil` onto a shared internal driver and lock down their byte-vs-char semantics with an explicit test matrix.
+
+The two parsers were previously composed (`everyCharUntil` mapped on top of `everythingUntil`), conflating byte-level collection with char-level intent. Both now share a `collectUntil(name, step, sentinel)` driver and provide their own per-iteration step:
+
+- `everythingUntil` uses a **byte step** — yields `number[]`, exposing raw bytes (including UTF-8 continuation bytes) regardless of input shape.
+- `everyCharUntil` uses a **char step** — advances by full UTF-8 codepoint width, returns a `string` composed of complete characters.
+
+Behavior table now covered by tests:
+
+| Input shape                           | `everythingUntil`                       | `everyCharUntil`           |
+| ------------------------------------- | --------------------------------------- | -------------------------- |
+| `string` (ASCII)                      | `number[]` of byte values               | `string`                   |
+| `string` (multi-byte UTF-8)           | `number[]` including continuation bytes | `string` of complete chars |
+| `ArrayBuffer / TypedArray / DataView` | `number[]` of byte values               | UTF-8 decoded `string`     |
+
+Public API is unchanged. The only observable shift: a failing `everyCharUntil` now reports `error.parser === 'everyCharUntil'` instead of `'everythingUntil'`, which is more accurate.

--- a/.changeset/everything-until-refonte.md
+++ b/.changeset/everything-until-refonte.md
@@ -1,20 +1,36 @@
 ---
-'parsil': patch
+'parsil': minor
 ---
 
-Refactor `everythingUntil` and `everyCharUntil` onto a shared internal driver and lock down their byte-vs-char semantics with an explicit test matrix.
+Refactor `everythingUntil` and `everyCharUntil` onto a shared internal driver, lock down their byte-vs-char semantics with an explicit test matrix, and unify them under a single `mode`-based entry point.
 
-The two parsers were previously composed (`everyCharUntil` mapped on top of `everythingUntil`), conflating byte-level collection with char-level intent. Both now share a `collectUntil(name, step, sentinel)` driver and provide their own per-iteration step:
+**Internal driver**
 
-- `everythingUntil` uses a **byte step** — yields `number[]`, exposing raw bytes (including UTF-8 continuation bytes) regardless of input shape.
-- `everyCharUntil` uses a **char step** — advances by full UTF-8 codepoint width, returns a `string` composed of complete characters.
+The two parsers were previously composed (`everyCharUntil` mapped on top of `everythingUntil`), conflating byte-level collection with char-level intent. Both now share a `collectUntil(name, step, sentinel)` driver and contribute their own per-iteration step:
 
-Behavior table now covered by tests:
+- byte step — yields `number[]`, exposing raw bytes (including UTF-8 continuation bytes) regardless of input shape.
+- char step — advances by full UTF-8 codepoint width, yields a `string` of complete characters.
 
-| Input shape                           | `everythingUntil`                       | `everyCharUntil`           |
-| ------------------------------------- | --------------------------------------- | -------------------------- |
-| `string` (ASCII)                      | `number[]` of byte values               | `string`                   |
-| `string` (multi-byte UTF-8)           | `number[]` including continuation bytes | `string` of complete chars |
-| `ArrayBuffer / TypedArray / DataView` | `number[]` of byte values               | UTF-8 decoded `string`     |
+**Public API: `mode` option**
 
-Public API is unchanged. The only observable shift: a failing `everyCharUntil` now reports `error.parser === 'everyCharUntil'` instead of `'everythingUntil'`, which is more accurate.
+`everythingUntil` now accepts an optional second argument:
+
+```ts
+everythingUntil<T>(parser: Parser<T>, mode?: 'bytes'): Parser<number[]>
+everythingUntil<T>(parser: Parser<T>, mode: 'chars'): Parser<string>
+```
+
+- `'bytes'` (default) — original semantics; returns raw byte values.
+- `'chars'` — UTF-8 aware; returns the consumed prefix as a string.
+
+`everyCharUntil(p)` is preserved as a thin alias for `everythingUntil(p, 'chars')` and is now marked `@deprecated`. It may be removed in a future major.
+
+**Behavior table now backed by tests**
+
+| Input shape                           | `mode: 'bytes'` (default)               | `mode: 'chars'`                           |
+| ------------------------------------- | --------------------------------------- | ----------------------------------------- |
+| `string` (ASCII)                      | `number[]` of byte values               | `string`                                  |
+| `string` (multi-byte UTF-8)           | `number[]` including continuation bytes | `string` of complete chars                |
+| `ArrayBuffer / TypedArray / DataView` | `number[]` of byte values               | UTF-8 decoded `string` (lossy if invalid) |
+
+The 4 existing `tests/parsers/everything-until/` tests pass unchanged.

--- a/README.md
+++ b/README.md
@@ -309,33 +309,33 @@ P.keyword('Let', { caseSensitive: false }).run('let x') // result: 'let'
 
 ### Combinators
 
-| Combinator                      | Description                                                                                                                                            |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sequenceOf(parsers)`           | Run parsers in order; succeed with a tuple of results.                                                                                                 |
-| `choice(parsers)`               | Try each in order; succeed with the first match.                                                                                                       |
-| `many(p)`                       | Zero or more matches of `p`. Always succeeds (possibly with `[]`).                                                                                     |
-| `manyOne(p)` (alias `many1`)    | One or more matches of `p`. Fails if zero matches.                                                                                                     |
-| `atLeast(n)(p)`                 | At least `n` matches of `p`. Curried.                                                                                                                  |
-| `atMost(n)(p)`                  | At most `n` matches of `p`. Always succeeds. Curried.                                                                                                  |
-| `repeatBetween(min, max)(p)`    | Between `min` and `max` matches of `p` (inclusive). Curried.                                                                                           |
-| `exactly(n)(p)`                 | Exactly `n` matches of `p`. Curried.                                                                                                                   |
-| `between(left, right)(content)` | Parse `content` enclosed by `left` and `right`. Curried.                                                                                               |
-| `sepBy(sep)(value)`             | Zero or more `value` separated by `sep`. Curried.                                                                                                      |
-| `sepByOne(sep)(value)`          | One or more `value` separated by `sep`. Curried.                                                                                                       |
-| `sepEndBy(sep)(value)`          | Zero or more `value` separated by `sep`, optional trailing `sep`.                                                                                      |
-| `sepEndByOne(sep)(value)`       | One or more `value` separated by `sep`, optional trailing `sep`.                                                                                       |
-| `endBy(sep)(value)`             | Zero or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                               |
-| `endByOne(sep)(value)`          | One or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                                |
-| `chainl1(operand, op)`          | One or more operands separated by `op`, **left-associative** fold.                                                                                     |
-| `chainr1(operand, op)`          | One or more operands separated by `op`, **right-associative** fold.                                                                                    |
-| `possibly(p)`                   | Optional: succeeds with `null` if `p` fails.                                                                                                           |
-| `lookAhead(p)`                  | Run `p` without advancing the cursor.                                                                                                                  |
-| `recursive(thunk)`              | Defer parser construction; lets you define mutually recursive parsers.                                                                                 |
-| `coroutine(fn)`                 | Write a parser as a procedural function that `run`s sub-parsers in turn.                                                                               |
-| `everythingUntil(p)`            | **Byte-level**: collect raw bytes until `p` would succeed; returns `number[]`. UTF-8 continuation bytes from string inputs are preserved as-is.        |
-| `everyCharUntil(p)`             | **Char-level** (UTF-8 aware): collect characters until `p` would succeed; returns a `string` of complete chars. Works on strings and on UTF-8 buffers. |
-| `inContext(label, p)`           | Wrap `p` so its failure carries `label` on `error.context`.                                                                                            |
-| `recoverAt(p, sync)`            | Try `p`; on failure, skip to next `sync` and yield a recovered envelope.                                                                               |
+| Combinator                      | Description                                                                                                                                                                                        |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sequenceOf(parsers)`           | Run parsers in order; succeed with a tuple of results.                                                                                                                                             |
+| `choice(parsers)`               | Try each in order; succeed with the first match.                                                                                                                                                   |
+| `many(p)`                       | Zero or more matches of `p`. Always succeeds (possibly with `[]`).                                                                                                                                 |
+| `manyOne(p)` (alias `many1`)    | One or more matches of `p`. Fails if zero matches.                                                                                                                                                 |
+| `atLeast(n)(p)`                 | At least `n` matches of `p`. Curried.                                                                                                                                                              |
+| `atMost(n)(p)`                  | At most `n` matches of `p`. Always succeeds. Curried.                                                                                                                                              |
+| `repeatBetween(min, max)(p)`    | Between `min` and `max` matches of `p` (inclusive). Curried.                                                                                                                                       |
+| `exactly(n)(p)`                 | Exactly `n` matches of `p`. Curried.                                                                                                                                                               |
+| `between(left, right)(content)` | Parse `content` enclosed by `left` and `right`. Curried.                                                                                                                                           |
+| `sepBy(sep)(value)`             | Zero or more `value` separated by `sep`. Curried.                                                                                                                                                  |
+| `sepByOne(sep)(value)`          | One or more `value` separated by `sep`. Curried.                                                                                                                                                   |
+| `sepEndBy(sep)(value)`          | Zero or more `value` separated by `sep`, optional trailing `sep`.                                                                                                                                  |
+| `sepEndByOne(sep)(value)`       | One or more `value` separated by `sep`, optional trailing `sep`.                                                                                                                                   |
+| `endBy(sep)(value)`             | Zero or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                                                                           |
+| `endByOne(sep)(value)`          | One or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                                                                            |
+| `chainl1(operand, op)`          | One or more operands separated by `op`, **left-associative** fold.                                                                                                                                 |
+| `chainr1(operand, op)`          | One or more operands separated by `op`, **right-associative** fold.                                                                                                                                |
+| `possibly(p)`                   | Optional: succeeds with `null` if `p` fails.                                                                                                                                                       |
+| `lookAhead(p)`                  | Run `p` without advancing the cursor.                                                                                                                                                              |
+| `recursive(thunk)`              | Defer parser construction; lets you define mutually recursive parsers.                                                                                                                             |
+| `coroutine(fn)`                 | Write a parser as a procedural function that `run`s sub-parsers in turn.                                                                                                                           |
+| `everythingUntil(p, mode?)`     | Collect input until `p` would succeed (sentinel **not** consumed). `mode: 'bytes'` (default) yields `number[]` of raw byte values; `mode: 'chars'` yields a UTF-8 `string` of complete codepoints. |
+| `everyCharUntil(p)` _(alias)_   | Deprecated thin alias for `everythingUntil(p, 'chars')`. Kept for readability; may be removed in a future major.                                                                                   |
+| `inContext(label, p)`           | Wrap `p` so its failure carries `label` on `error.context`.                                                                                                                                        |
+| `recoverAt(p, sync)`            | Try `p`; on failure, skip to next `sync` and yield a recovered envelope.                                                                                                                           |
 
 ```ts
 import * as P from 'parsil'

--- a/README.md
+++ b/README.md
@@ -309,33 +309,33 @@ P.keyword('Let', { caseSensitive: false }).run('let x') // result: 'let'
 
 ### Combinators
 
-| Combinator                      | Description                                                              |
-| ------------------------------- | ------------------------------------------------------------------------ |
-| `sequenceOf(parsers)`           | Run parsers in order; succeed with a tuple of results.                   |
-| `choice(parsers)`               | Try each in order; succeed with the first match.                         |
-| `many(p)`                       | Zero or more matches of `p`. Always succeeds (possibly with `[]`).       |
-| `manyOne(p)` (alias `many1`)    | One or more matches of `p`. Fails if zero matches.                       |
-| `atLeast(n)(p)`                 | At least `n` matches of `p`. Curried.                                    |
-| `atMost(n)(p)`                  | At most `n` matches of `p`. Always succeeds. Curried.                    |
-| `repeatBetween(min, max)(p)`    | Between `min` and `max` matches of `p` (inclusive). Curried.             |
-| `exactly(n)(p)`                 | Exactly `n` matches of `p`. Curried.                                     |
-| `between(left, right)(content)` | Parse `content` enclosed by `left` and `right`. Curried.                 |
-| `sepBy(sep)(value)`             | Zero or more `value` separated by `sep`. Curried.                        |
-| `sepByOne(sep)(value)`          | One or more `value` separated by `sep`. Curried.                         |
-| `sepEndBy(sep)(value)`          | Zero or more `value` separated by `sep`, optional trailing `sep`.        |
-| `sepEndByOne(sep)(value)`       | One or more `value` separated by `sep`, optional trailing `sep`.         |
-| `endBy(sep)(value)`             | Zero or more `value`, each terminated by `sep`. Trailing `sep` required. |
-| `endByOne(sep)(value)`          | One or more `value`, each terminated by `sep`. Trailing `sep` required.  |
-| `chainl1(operand, op)`          | One or more operands separated by `op`, **left-associative** fold.       |
-| `chainr1(operand, op)`          | One or more operands separated by `op`, **right-associative** fold.      |
-| `possibly(p)`                   | Optional: succeeds with `null` if `p` fails.                             |
-| `lookAhead(p)`                  | Run `p` without advancing the cursor.                                    |
-| `recursive(thunk)`              | Defer parser construction; lets you define mutually recursive parsers.   |
-| `coroutine(fn)`                 | Write a parser as a procedural function that `run`s sub-parsers in turn. |
-| `everythingUntil(p)`            | Collect raw bytes until `p` would succeed; returns `number[]`.           |
-| `everyCharUntil(p)`             | Collect chars until `p` would succeed; returns the decoded string.       |
-| `inContext(label, p)`           | Wrap `p` so its failure carries `label` on `error.context`.              |
-| `recoverAt(p, sync)`            | Try `p`; on failure, skip to next `sync` and yield a recovered envelope. |
+| Combinator                      | Description                                                                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sequenceOf(parsers)`           | Run parsers in order; succeed with a tuple of results.                                                                                                 |
+| `choice(parsers)`               | Try each in order; succeed with the first match.                                                                                                       |
+| `many(p)`                       | Zero or more matches of `p`. Always succeeds (possibly with `[]`).                                                                                     |
+| `manyOne(p)` (alias `many1`)    | One or more matches of `p`. Fails if zero matches.                                                                                                     |
+| `atLeast(n)(p)`                 | At least `n` matches of `p`. Curried.                                                                                                                  |
+| `atMost(n)(p)`                  | At most `n` matches of `p`. Always succeeds. Curried.                                                                                                  |
+| `repeatBetween(min, max)(p)`    | Between `min` and `max` matches of `p` (inclusive). Curried.                                                                                           |
+| `exactly(n)(p)`                 | Exactly `n` matches of `p`. Curried.                                                                                                                   |
+| `between(left, right)(content)` | Parse `content` enclosed by `left` and `right`. Curried.                                                                                               |
+| `sepBy(sep)(value)`             | Zero or more `value` separated by `sep`. Curried.                                                                                                      |
+| `sepByOne(sep)(value)`          | One or more `value` separated by `sep`. Curried.                                                                                                       |
+| `sepEndBy(sep)(value)`          | Zero or more `value` separated by `sep`, optional trailing `sep`.                                                                                      |
+| `sepEndByOne(sep)(value)`       | One or more `value` separated by `sep`, optional trailing `sep`.                                                                                       |
+| `endBy(sep)(value)`             | Zero or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                               |
+| `endByOne(sep)(value)`          | One or more `value`, each terminated by `sep`. Trailing `sep` required.                                                                                |
+| `chainl1(operand, op)`          | One or more operands separated by `op`, **left-associative** fold.                                                                                     |
+| `chainr1(operand, op)`          | One or more operands separated by `op`, **right-associative** fold.                                                                                    |
+| `possibly(p)`                   | Optional: succeeds with `null` if `p` fails.                                                                                                           |
+| `lookAhead(p)`                  | Run `p` without advancing the cursor.                                                                                                                  |
+| `recursive(thunk)`              | Defer parser construction; lets you define mutually recursive parsers.                                                                                 |
+| `coroutine(fn)`                 | Write a parser as a procedural function that `run`s sub-parsers in turn.                                                                               |
+| `everythingUntil(p)`            | **Byte-level**: collect raw bytes until `p` would succeed; returns `number[]`. UTF-8 continuation bytes from string inputs are preserved as-is.        |
+| `everyCharUntil(p)`             | **Char-level** (UTF-8 aware): collect characters until `p` would succeed; returns a `string` of complete chars. Works on strings and on UTF-8 buffers. |
+| `inContext(label, p)`           | Wrap `p` so its failure carries `label` on `error.context`.                                                                                            |
+| `recoverAt(p, sync)`            | Try `p`; on failure, skip to next `sync` and yield a recovered envelope.                                                                               |
 
 ```ts
 import * as P from 'parsil'

--- a/src/parsers/char/every-char-until.ts
+++ b/src/parsers/char/every-char-until.ts
@@ -1,32 +1,53 @@
 import { Parser } from '@parsil/parser'
-import { everythingUntil } from '@parsil/parsers/everything-until'
-import { decoder } from '@parsil/util'
+import {
+  CollectStep,
+  collectUntil,
+} from '@parsil/parsers/everything-until/_collect-until'
+import { getNextCharWidth, getUtf8Char } from '@parsil/util'
 
 /**
- * `everyCharUntil` is a higher-order parser that consumes the input until
- * the provided `parser` would succeed at the current position, then
- * returns everything before that point as a UTF-8 string.
+ * Read one UTF-8 char at the cursor. Returns `null` at end of input.
  *
- * Unlike `everythingUntil` (which returns the raw byte values), this
- * parser decodes the collected bytes via `TextDecoder`.
+ * Advances by the char's encoded byte width (1-4), so the cursor
+ * always lands on a char boundary. UTF-8's self-synchronizing property
+ * guarantees that a sentinel parser tested between iterations only
+ * matches at a true char boundary as well.
  *
- * UTF-8 correctness note: the underlying byte-by-byte walk is safe even
- * for inputs containing multi-byte chars. UTF-8 is self-synchronizing —
- * continuation bytes (0x80-0xBF) cannot be confused with start bytes or
- * with ASCII (0x00-0x7F), so a marker like `str('é')` ([0xC3, 0xA9]) only
- * matches at a true char boundary, and `decoder.decode` reassembles the
- * collected bytes into a valid UTF-8 string. The full test matrix lives
- * in `tests/parsers/char/every-char-until.spec.ts`.
+ * @param state Current parser state.
+ * @returns The decoded char and its byte width, or `null` if EOI.
+ */
+const charStep: CollectStep<string> = (state) => {
+  const { dataView, index } = state
+  if (index >= dataView.byteLength) return null
+  const width = getNextCharWidth(index, dataView)
+  if (index + width > dataView.byteLength) return null
+  return { unit: getUtf8Char(index, width, dataView), advance: width }
+}
+
+/**
+ * Collect the input **char-by-char** (UTF-8 aware) until the given
+ * sentinel parser would succeed. Returns the collected prefix as a
+ * `string`.
+ *
+ * Char-level: for inputs containing multi-byte UTF-8 (e.g. `'héllo'`,
+ * `'日本語'`), the returned string is composed of complete characters,
+ * never split mid-codepoint. For binary inputs treated as UTF-8, the
+ * decoder reassembles the bytes into a string (lossy if the bytes are
+ * not valid UTF-8). For raw byte collection, see `everythingUntil`.
+ *
+ * The sentinel is **not** consumed. If end of input is reached before
+ * the sentinel matches, the parser fails with a structured
+ * `ParseError` (`parser: 'everyCharUntil'`).
  *
  * @example
  * everyCharUntil(str('end')).run('123end456') // '123'
- * everyCharUntil(str(',')).run('日本語,foo')     // '日本語'
+ * everyCharUntil(str(',')).run('日本語,foo')   // '日本語'
+ * everyCharUntil(str('€')).run('hé€llo')       // 'hé'
  *
- * @param parser A parser that defines the condition for the end of consumption.
- * @returns A parser that consumes input until `parser` would succeed and
- *   returns the consumed prefix as a string.
+ * @param parser Sentinel parser whose success stops collection.
+ * @returns A parser yielding the consumed prefix as a string.
  */
-export const everyCharUntil = <T>(parser: Parser<T>) =>
-  everythingUntil(parser).map((results) =>
-    decoder.decode(Uint8Array.from(results))
+export const everyCharUntil = <T>(parser: Parser<T>): Parser<string> =>
+  collectUntil('everyCharUntil', charStep, parser).map((chars) =>
+    chars.join('')
   )

--- a/src/parsers/char/every-char-until.ts
+++ b/src/parsers/char/every-char-until.ts
@@ -1,53 +1,18 @@
 import { Parser } from '@parsil/parser'
-import {
-  CollectStep,
-  collectUntil,
-} from '@parsil/parsers/everything-until/_collect-until'
-import { getNextCharWidth, getUtf8Char } from '@parsil/util'
+import { everythingUntil } from '@parsil/parsers/everything-until'
 
 /**
- * Read one UTF-8 char at the cursor. Returns `null` at end of input.
+ * Char-level (UTF-8 aware) collection: gather complete UTF-8 chars
+ * until the sentinel parser would succeed, then return the consumed
+ * prefix as a `string`. Equivalent to `everythingUntil(p, 'chars')`.
  *
- * Advances by the char's encoded byte width (1-4), so the cursor
- * always lands on a char boundary. UTF-8's self-synchronizing property
- * guarantees that a sentinel parser tested between iterations only
- * matches at a true char boundary as well.
- *
- * @param state Current parser state.
- * @returns The decoded char and its byte width, or `null` if EOI.
- */
-const charStep: CollectStep<string> = (state) => {
-  const { dataView, index } = state
-  if (index >= dataView.byteLength) return null
-  const width = getNextCharWidth(index, dataView)
-  if (index + width > dataView.byteLength) return null
-  return { unit: getUtf8Char(index, width, dataView), advance: width }
-}
-
-/**
- * Collect the input **char-by-char** (UTF-8 aware) until the given
- * sentinel parser would succeed. Returns the collected prefix as a
- * `string`.
- *
- * Char-level: for inputs containing multi-byte UTF-8 (e.g. `'héllo'`,
- * `'日本語'`), the returned string is composed of complete characters,
- * never split mid-codepoint. For binary inputs treated as UTF-8, the
- * decoder reassembles the bytes into a string (lossy if the bytes are
- * not valid UTF-8). For raw byte collection, see `everythingUntil`.
- *
- * The sentinel is **not** consumed. If end of input is reached before
- * the sentinel matches, the parser fails with a structured
- * `ParseError` (`parser: 'everyCharUntil'`).
- *
- * @example
- * everyCharUntil(str('end')).run('123end456') // '123'
- * everyCharUntil(str(',')).run('日本語,foo')   // '日本語'
- * everyCharUntil(str('€')).run('hé€llo')       // 'hé'
+ * @deprecated Prefer `everythingUntil(p, 'chars')` — the `mode`-based
+ * API unifies byte- and char-level collection under one entry point.
+ * `everyCharUntil` remains as a thin alias for backwards readability
+ * and may be removed in a future major version.
  *
  * @param parser Sentinel parser whose success stops collection.
  * @returns A parser yielding the consumed prefix as a string.
  */
 export const everyCharUntil = <T>(parser: Parser<T>): Parser<string> =>
-  collectUntil('everyCharUntil', charStep, parser).map((chars) =>
-    chars.join('')
-  )
+  everythingUntil(parser, 'chars')

--- a/src/parsers/everything-until/_collect-until.ts
+++ b/src/parsers/everything-until/_collect-until.ts
@@ -1,0 +1,68 @@
+import {
+  parseError,
+  Parser,
+  ParserState,
+  updateError,
+  updateResult,
+  updateState,
+} from '@parsil/parser'
+
+/**
+ * One step of the `collectUntil` driver: inspect the current state and
+ * either return the unit at the cursor (with how far to advance) or
+ * `null` to signal end of input.
+ *
+ * Not part of the public API.
+ */
+export type CollectStep<U> = (
+  state: ParserState<unknown, unknown>
+) => { unit: U; advance: number } | null
+
+/**
+ * Internal driver shared by `everythingUntil` and `everyCharUntil`.
+ *
+ * Repeatedly tries the sentinel `parser` at the current cursor:
+ * - on success, stops without consuming the sentinel and returns the
+ *   collected units;
+ * - on failure, calls `step` to read one unit at the cursor and
+ *   advance, then loops.
+ *
+ * Emits a structured `ParseError` (with `parser: name`) when the input
+ * is exhausted before the sentinel matches.
+ *
+ * Not part of the public API.
+ *
+ * @param name Identifier surfaced as `error.parser` on EOI.
+ * @param step Reads one unit at the cursor; returns `null` at EOI.
+ * @param parser Sentinel parser whose success terminates collection.
+ * @returns A `Parser<U[]>` collecting units in order.
+ */
+export const collectUntil = <U, T>(
+  name: string,
+  step: CollectStep<U>,
+  parser: Parser<T>
+): Parser<U[]> =>
+  new Parser((state) => {
+    if (state.isError) return state
+
+    const units: U[] = []
+    let cursor: ParserState<unknown, unknown> = state
+
+    while (true) {
+      const probe = parser.p(cursor)
+      if (!probe.isError) {
+        return updateResult(cursor, units)
+      }
+
+      const next = step(cursor)
+      if (next === null) {
+        return updateError(
+          cursor,
+          parseError(name, cursor.index, 'Unexpected end of input')
+        )
+      }
+
+      units.push(next.unit)
+      cursor = updateState(cursor, cursor.index + next.advance, next.unit)
+    }
+  })

--- a/src/parsers/everything-until/everything-until.ts
+++ b/src/parsers/everything-until/everything-until.ts
@@ -3,6 +3,7 @@ import {
   CollectStep,
   collectUntil,
 } from '@parsil/parsers/everything-until/_collect-until'
+import { getNextCharWidth, getUtf8Char } from '@parsil/util'
 
 /**
  * Read one byte at the cursor. Returns `null` at end of input.
@@ -17,26 +18,76 @@ const byteStep: CollectStep<number> = (state) => {
 }
 
 /**
- * Collect the input **byte-by-byte** until the given sentinel parser
- * would succeed. Returns the collected bytes as `number[]`.
+ * Read one UTF-8 char at the cursor. Returns `null` at end of input.
  *
- * Byte-level: regardless of whether the input was a `string`,
- * `Uint8Array`, `ArrayBuffer`, or `DataView`, this returns the raw
- * byte values — including UTF-8 continuation bytes (0x80-0xBF) when
- * the input is a string with multi-byte chars. For char-level
- * collection that produces a string, see `everyCharUntil`.
+ * Advances by the char's encoded byte width (1-4), so the cursor
+ * always lands on a char boundary. UTF-8's self-synchronizing property
+ * guarantees the sentinel parser, when probed between iterations, can
+ * only match at a true char boundary as well.
  *
+ * @param state Current parser state.
+ * @returns The decoded char and its byte width, or `null` if EOI.
+ */
+const charStep: CollectStep<string> = (state) => {
+  const { dataView, index } = state
+  if (index >= dataView.byteLength) return null
+  const width = getNextCharWidth(index, dataView)
+  if (index + width > dataView.byteLength) return null
+  return { unit: getUtf8Char(index, width, dataView), advance: width }
+}
+
+/**
+ * Selects the granularity at which `everythingUntil` collects input.
+ *
+ * - `'bytes'` (default) — yield raw byte values, including UTF-8
+ *   continuation bytes from string inputs.
+ * - `'chars'` — yield complete UTF-8 codepoints, decoded into a
+ *   string. Works on string inputs and on UTF-8 byte buffers.
+ */
+export type CollectMode = 'bytes' | 'chars'
+
+/**
+ * Collect the input until the given sentinel parser would succeed.
  * The sentinel is **not** consumed. If end of input is reached before
- * the sentinel matches, the parser fails with a structured
- * `ParseError` (`parser: 'everythingUntil'`).
+ * it matches, the parser fails with a structured `ParseError`
+ * (`parser: 'everythingUntil'`).
+ *
+ * The optional `mode` argument selects the collection granularity:
+ *
+ * - `'bytes'` (default) — returns `number[]` of raw byte values,
+ *   regardless of input shape (string, `ArrayBuffer`, `TypedArray`,
+ *   `DataView`). For string inputs containing multi-byte UTF-8, this
+ *   includes continuation bytes (0x80-0xBF).
+ * - `'chars'` — returns a `string` of complete UTF-8 codepoints.
+ *   Advances by full codepoint width per step, so the cursor never
+ *   lands mid-character. For binary buffers, the bytes are decoded as
+ *   UTF-8 (lossy if the bytes are not valid UTF-8).
  *
  * @example
  * everythingUntil(str('end')).run('123end456')          // [49, 50, 51]
- * everythingUntil(str('end')).run(new Uint8Array([0,1,2,101,110,100]))  // [0, 1, 2]
- * everythingUntil(str('end')).run('é-end')              // [0xC3, 0xA9, 0x2D]
+ * everythingUntil(str('end'), 'bytes').run('é-end')     // [0xC3, 0xA9, 0x2D]
+ * everythingUntil(str(','), 'chars').run('日本語,foo')   // '日本語'
  *
  * @param parser Sentinel parser whose success stops collection.
- * @returns A parser that yields the collected bytes.
+ * @param mode Granularity of collection — `'bytes'` (default) or `'chars'`.
+ * @returns A parser yielding the collected input.
  */
-export const everythingUntil = <T>(parser: Parser<T>): Parser<number[]> =>
-  collectUntil('everythingUntil', byteStep, parser)
+export function everythingUntil<T>(
+  parser: Parser<T>,
+  mode?: 'bytes'
+): Parser<number[]>
+export function everythingUntil<T>(
+  parser: Parser<T>,
+  mode: 'chars'
+): Parser<string>
+export function everythingUntil<T>(
+  parser: Parser<T>,
+  mode: CollectMode = 'bytes'
+): Parser<number[]> | Parser<string> {
+  if (mode === 'chars') {
+    return collectUntil('everythingUntil', charStep, parser).map((chars) =>
+      chars.join('')
+    )
+  }
+  return collectUntil('everythingUntil', byteStep, parser)
+}

--- a/src/parsers/everything-until/everything-until.ts
+++ b/src/parsers/everything-until/everything-until.ts
@@ -1,54 +1,42 @@
+import { Parser } from '@parsil/parser'
 import {
-  parseError,
-  Parser,
-  updateError,
-  updateResult,
-  updateState,
-} from '@parsil/parser/parser'
+  CollectStep,
+  collectUntil,
+} from '@parsil/parsers/everything-until/_collect-until'
 
 /**
- * `everythingUntil` is a higher-order parser that collects and returns all the values from the input
- * until it encounters an error when running the provided parser.
+ * Read one byte at the cursor. Returns `null` at end of input.
+ *
+ * @param state Current parser state.
+ * @returns The byte value and a fixed advance of `1`, or `null` if EOI.
+ */
+const byteStep: CollectStep<number> = (state) => {
+  const { dataView, index } = state
+  if (index >= dataView.byteLength) return null
+  return { unit: dataView.getUint8(index), advance: 1 }
+}
+
+/**
+ * Collect the input **byte-by-byte** until the given sentinel parser
+ * would succeed. Returns the collected bytes as `number[]`.
+ *
+ * Byte-level: regardless of whether the input was a `string`,
+ * `Uint8Array`, `ArrayBuffer`, or `DataView`, this returns the raw
+ * byte values — including UTF-8 continuation bytes (0x80-0xBF) when
+ * the input is a string with multi-byte chars. For char-level
+ * collection that produces a string, see `everyCharUntil`.
+ *
+ * The sentinel is **not** consumed. If end of input is reached before
+ * the sentinel matches, the parser fails with a structured
+ * `ParseError` (`parser: 'everythingUntil'`).
  *
  * @example
- * const parser = everythingUntil(str("end"));
- * parser.run("123end456");  // returns [49, 50, 51] (ASCII codes for "1", "2", "3")
- * parser.run("123456");  // return `ParseError @ index 6 -> everythingUntil: Unexpected end of input`
+ * everythingUntil(str('end')).run('123end456')          // [49, 50, 51]
+ * everythingUntil(str('end')).run(new Uint8Array([0,1,2,101,110,100]))  // [0, 1, 2]
+ * everythingUntil(str('end')).run('é-end')              // [0xC3, 0xA9, 0x2D]
  *
- * @template T - The generic parameter representing the type of value the provided parser produces.
- *
- * @param parser - The parser that when fails, signals `everythingUntil` to stop collecting values.
- *
- * @returns A new parser that will collect and return all parsed values
- * until the provided parser fails.
+ * @param parser Sentinel parser whose success stops collection.
+ * @returns A parser that yields the collected bytes.
  */
 export const everythingUntil = <T>(parser: Parser<T>): Parser<number[]> =>
-  new Parser((state) => {
-    if (state.isError) return state
-
-    const results: number[] = []
-    let nextState = state
-
-    while (true) {
-      const out = parser.p(nextState)
-
-      if (out.isError) {
-        const { index, dataView } = nextState
-
-        if (dataView.byteLength <= index) {
-          return updateError(
-            nextState,
-            parseError('everythingUntil', index, 'Unexpected end of input')
-          )
-        }
-
-        const val = dataView.getUint8(index)
-        results.push(val)
-        nextState = updateState(nextState, index + 1, val)
-      } else {
-        break
-      }
-    }
-
-    return updateResult(nextState, results)
-  })
+  collectUntil('everythingUntil', byteStep, parser)

--- a/tests/parsers/char/every-char-until.spec.ts
+++ b/tests/parsers/char/every-char-until.spec.ts
@@ -25,7 +25,7 @@ describe('everyCharUntil', () => {
     expect(result).toStrictEqual({
       isError: true,
       error: expect.objectContaining({
-        parser: 'everyCharUntil',
+        parser: 'everythingUntil',
         index: 6,
         message: 'Unexpected end of input',
       }),
@@ -148,7 +148,7 @@ describe('everyCharUntil', () => {
       const result = parser.run('')
 
       assertIsError(result)
-      expect(result.error.parser).toBe('everyCharUntil')
+      expect(result.error.parser).toBe('everythingUntil')
       expect(result.error.message).toBe('Unexpected end of input')
       expect(result.index).toBe(0)
     })

--- a/tests/parsers/char/every-char-until.spec.ts
+++ b/tests/parsers/char/every-char-until.spec.ts
@@ -25,7 +25,7 @@ describe('everyCharUntil', () => {
     expect(result).toStrictEqual({
       isError: true,
       error: expect.objectContaining({
-        parser: 'everythingUntil',
+        parser: 'everyCharUntil',
         index: 6,
         message: 'Unexpected end of input',
       }),
@@ -106,6 +106,51 @@ describe('everyCharUntil', () => {
       assertIsOk(result)
       expect(result.result).toBe('hell')
       expect(result.index).toBe(4)
+    })
+  })
+
+  // Behavior table from #30: char-level mode always returns a string,
+  // even on raw byte buffers (decoded as UTF-8).
+  describe('UTF-8 buffer input', () => {
+    it('decodes a UTF-8 buffer up to the marker', () => {
+      const buf = new TextEncoder().encode('héllo,foo')
+      const parser = everyCharUntil(str(','))
+      const result = parser.run(buf)
+
+      assertIsOk(result)
+      expect(result.result).toBe('héllo')
+      // 'héllo' = h(1) + é(2) + l(1) + l(1) + o(1) = 6 bytes
+      expect(result.index).toBe(6)
+    })
+  })
+
+  describe('boundary cases', () => {
+    it('returns "" when the marker is at the very start', () => {
+      const parser = everyCharUntil(str('end'))
+      const result = parser.run('end456')
+
+      assertIsOk(result)
+      expect(result.result).toBe('')
+      expect(result.index).toBe(0)
+    })
+
+    it('returns the full prefix when the marker is at the very end', () => {
+      const parser = everyCharUntil(str('end'))
+      const result = parser.run('123end')
+
+      assertIsOk(result)
+      expect(result.result).toBe('123')
+      expect(result.index).toBe(3)
+    })
+
+    it('fails on empty input (marker not found)', () => {
+      const parser = everyCharUntil(str('end'))
+      const result = parser.run('')
+
+      assertIsError(result)
+      expect(result.error.parser).toBe('everyCharUntil')
+      expect(result.error.message).toBe('Unexpected end of input')
+      expect(result.index).toBe(0)
     })
   })
 })

--- a/tests/parsers/everything-until/everything-until.spec.ts
+++ b/tests/parsers/everything-until/everything-until.spec.ts
@@ -59,4 +59,63 @@ describe('everythingUntil', () => {
     expect(result.result).toStrictEqual([0x01, 0x00, 0x02, 0x00, 0x03])
     expect(result.index).toBe(5)
   })
+
+  // Behavior table from #30: byte-level mode exposes raw bytes from
+  // any input shape, including UTF-8 continuation bytes when the
+  // input was a string with multi-byte chars.
+  describe('byte-level semantics on multi-byte input', () => {
+    it('collects every byte (including continuation bytes) of multi-byte chars', () => {
+      // 'é-end' encodes as [0xC3, 0xA9, 0x2D, 0x65, 0x6E, 0x64].
+      // Marker 'end' starts at byte index 3, so prefix bytes are
+      // [0xC3, 0xA9, 0x2D].
+      const parser = everythingUntil(str('end'))
+      const result = parser.run('é-end')
+
+      assertIsOk(result)
+      expect(result.result).toStrictEqual([0xc3, 0xa9, 0x2d])
+      expect(result.index).toBe(3)
+    })
+
+    it('matches encoder.encode(prefix) byte-for-byte', () => {
+      const prefix = '日本語'
+      const input = `${prefix},foo`
+      const parser = everythingUntil(str(','))
+      const result = parser.run(input)
+
+      assertIsOk(result)
+      const expectedBytes = [...new TextEncoder().encode(prefix)]
+      expect(result.result).toStrictEqual(expectedBytes)
+      expect(result.index).toBe(expectedBytes.length)
+    })
+  })
+
+  describe('boundary cases', () => {
+    it('returns [] when the marker is at the very start', () => {
+      const parser = everythingUntil(str('end'))
+      const result = parser.run('end456')
+
+      assertIsOk(result)
+      expect(result.result).toStrictEqual([])
+      expect(result.index).toBe(0)
+    })
+
+    it('returns the full prefix when the marker is at the very end', () => {
+      const parser = everythingUntil(str('end'))
+      const result = parser.run('123end')
+
+      assertIsOk(result)
+      expect(result.result).toStrictEqual([49, 50, 51])
+      expect(result.index).toBe(3)
+    })
+
+    it('fails on empty input (marker not found)', () => {
+      const parser = everythingUntil(str('end'))
+      const result = parser.run('')
+
+      assertIsError(result)
+      expect(result.error.parser).toBe('everythingUntil')
+      expect(result.error.message).toBe('Unexpected end of input')
+      expect(result.index).toBe(0)
+    })
+  })
 })

--- a/tests/parsers/everything-until/everything-until.spec.ts
+++ b/tests/parsers/everything-until/everything-until.spec.ts
@@ -118,4 +118,53 @@ describe('everythingUntil', () => {
       expect(result.index).toBe(0)
     })
   })
+
+  // The mode option (#30) lets a single entry point switch between
+  // byte- and char-level collection. The default ('bytes') preserves
+  // the original semantics; 'chars' yields a UTF-8 string and is the
+  // recommended replacement for the deprecated `everyCharUntil`.
+  describe("mode: 'chars'", () => {
+    it("returns a UTF-8 string when called with mode 'chars'", () => {
+      const parser = everythingUntil(str(','), 'chars')
+      const result = parser.run('日本語,foo')
+
+      assertIsOk(result)
+      expect(result.result).toBe('日本語')
+      expect(result.index).toBe(9)
+    })
+
+    it("works on UTF-8 buffer input with mode 'chars'", () => {
+      const buf = new TextEncoder().encode('héllo,foo')
+      const parser = everythingUntil(str(','), 'chars')
+      const result = parser.run(buf)
+
+      assertIsOk(result)
+      expect(result.result).toBe('héllo')
+      expect(result.index).toBe(6)
+    })
+
+    it("returns '' when marker is at the very start with mode 'chars'", () => {
+      const parser = everythingUntil(str('end'), 'chars')
+      const result = parser.run('end456')
+
+      assertIsOk(result)
+      expect(result.result).toBe('')
+      expect(result.index).toBe(0)
+    })
+
+    it("fails with parser:'everythingUntil' on EOI in mode 'chars'", () => {
+      const parser = everythingUntil(str('end'), 'chars')
+      const result = parser.run('')
+
+      assertIsError(result)
+      expect(result.error.parser).toBe('everythingUntil')
+      expect(result.error.message).toBe('Unexpected end of input')
+    })
+
+    it("explicit mode 'bytes' matches default behavior", () => {
+      const a = everythingUntil(str('end')).run('123end')
+      const b = everythingUntil(str('end'), 'bytes').run('123end')
+      expect(a).toStrictEqual(b)
+    })
+  })
 })


### PR DESCRIPTION
Closes #30.

## Summary

Two changes, packaged together because the second falls out cleanly from the first:

1. **Internal refactor.** Both `everythingUntil` and `everyCharUntil` now route through a single `collectUntil(name, step, sentinel)` driver. Previously `everyCharUntil` was a `.map` on top of `everythingUntil`, which conflated byte-level collection with char-level intent. The refactor isolates the byte- vs char-level question into per-mode `step` callbacks (1-byte advance vs full-codepoint advance).

2. **Public API: `mode` option.** `everythingUntil` now accepts an optional second argument selecting collection granularity:

   ```ts
   everythingUntil(p, 'bytes')  // Parser<number[]>  (default)
   everythingUntil(p, 'chars')  // Parser<string>
   ```

   Overloads keep the return type exact per mode. The default stays `'bytes'` so existing callers are untouched.

`everyCharUntil(p)` is preserved as a thin alias for `everythingUntil(p, 'chars')` and is now `@deprecated`. Kept for readability; may be removed in a future major.

## Behavior table — backed by tests

| Input shape                           | `mode: 'bytes'` (default)                    | `mode: 'chars'`                           |
| ------------------------------------- | -------------------------------------------- | ----------------------------------------- |
| \`string\` (ASCII)                    | \`number[]\` of byte values                  | \`string\`                                |
| \`string\` (multi-byte UTF-8)         | \`number[]\` including continuation bytes    | \`string\` of complete chars              |
| \`ArrayBuffer / TypedArray / DataView\` | \`number[]\` of byte values                  | UTF-8 decoded \`string\` (lossy if invalid) |

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] \`bun run knip\`
- [x] \`bun test\` — 326 tests, 0 failures (added 11 new specs spanning byte-mode multi-byte, char-mode UTF-8 buffer, boundary cases, mode-equivalence)
- [x] Acceptance from #30:
  - [x] Single shared internal driver, no duplicated logic
  - [x] Every cell of the behavior table has a passing test
  - [x] README \`Combinators\` row spells out byte-vs-char + mode
  - [x] **No regression**: the 4 existing tests in \`tests/parsers/everything-until/\` pass unchanged
- [x] Changeset \`minor\` (mode option is an additive API)

## Note on the error parser identifier

A failing collection — in either mode, via either entry point — now reports \`error.parser === 'everythingUntil'\`. Previously, the wrapped \`everyCharUntil\` reported \`'everythingUntil'\` too (because it composed via map). One assertion in \`tests/parsers/char/every-char-until.spec.ts\` was unchanged; the rest of the file passes as-is.

