### PR TITLE
chore(meta): bump Node to >=22 + add coverage reporting

### DIFF
--- a/.changeset/node-22-coverage.md
+++ b/.changeset/node-22-coverage.md
@@ -1,0 +1,16 @@
+---
+'parsil': patch
+---
+
+Bump Node engine floor to `>=22` and Bun to `>=1.3`. Add test coverage reporting.
+
+**Engine bump**
+
+Node 20 enters maintenance later this year; 22 has been the LTS since October 2024. Bumping in v3.0.0 means the breaking-engine cost lands in the same release as the API breaks (#29) — no separate dot-release just for engines. Updated `package.json` `engines`, `release.yml` Node setup step (used by `npm publish`), and the README **Engines** line so the published constraints, the publish workflow, and the docs all agree.
+
+**Coverage**
+
+- `bun run test:coverage` produces a text summary in the console and an `lcov.info` file under `coverage/` (suitable for Codecov, IDE coverage gutters, etc.).
+- A `coverage` job in `ci.yml` runs the script on every push and uploads the lcov as a 30-day artifact.
+- `coverage/` added to `.gitignore`.
+- No threshold gate yet — we establish a baseline and gate in a follow-up once the v3.0.0 cycle has settled.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -24,7 +24,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.skip.outputs.skip != 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,47 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
           fail-on-cache-miss: true
-      - run: bun run test:coverage
+
+      # Run coverage and capture both the text table (for the job
+      # summary on GitHub) and the lcov file (for the artifact).
+      - name: Run coverage
+        id: coverage
+        run: |
+          mkdir -p coverage
+          bun run test:coverage 2>&1 | tee coverage/run.log
+          # Bun's text reporter prints a 3-ruler table:
+          #   ----- (ruler 1)
+          #   File   | % Funcs | % Lines | Uncovered Line #s
+          #   ----- (ruler 2)
+          #   ...rows...
+          #   ----- (ruler 3)
+          # Capture from ruler 1 to ruler 3 inclusive.
+          awk 'BEGIN{c=0} /^-+\|/{c++; print; if(c==3) exit; next} c>0' \
+            coverage/run.log > coverage/table.txt
+          # Pull the totals row (% Funcs / % Lines for "All files").
+          grep -E '^\s*All files' coverage/run.log > coverage/totals.txt || true
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Test coverage"
+            echo
+            if [ -s coverage/totals.txt ]; then
+              echo "**Totals:** \`$(cat coverage/totals.txt | xargs)\`"
+              echo
+            fi
+            echo '<details><summary>Per-file coverage</summary>'
+            echo
+            echo '```'
+            cat coverage/table.txt
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo '_Full \`lcov.info\` is uploaded as a 30-day workflow artifact._'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,25 @@ jobs:
           key: node-modules-${{ hashFiles('bun.lock') }}
           fail-on-cache-miss: true
       - run: bun run build
+
+  coverage:
+    name: Coverage
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('bun.lock') }}
+          fail-on-cache-miss: true
+      - run: bun run test:coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     name: Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -29,11 +29,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -45,11 +45,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -61,11 +61,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -77,11 +77,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -93,11 +93,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -109,11 +109,11 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('bun.lock') }}
@@ -159,7 +159,7 @@ jobs:
             echo '_Full \`lcov.info\` is uploaded as a 30-day workflow artifact._'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: coverage/lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.notes.outputs.tag }}
           name: Release ${{ steps.notes.outputs.tag }}
@@ -71,7 +71,7 @@ jobs:
           prerelease: false
 
       - name: Setup Node.js for NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js for NPM
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to NPM

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@
 # Ignore Node.js runtime artifacts
 node_modules/
 
+# Ignore test coverage reports
+coverage/
+
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bun add parsil
 > const P = await import('parsil')
 > ```
 
-**Engines**: Node ≥ 20, Bun ≥ 1.1.
+**Engines**: Node ≥ 22, Bun ≥ 1.3.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "bun run clean && bun run build:esm && bun run build:types",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit",
     "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "lint": "bunx eslint . --max-warnings 0",
     "lint:fix": "bunx eslint . --fix --max-warnings 0",
     "format": "bunx prettier . -w",
@@ -63,8 +64,8 @@
     "typescript-eslint": "^8.59.2"
   },
   "engines": {
-    "node": ">=20",
-    "bun": ">=1.1"
+    "node": ">=22",
+    "bun": ">=1.3"
   },
   "keywords": [
     "parser",


### PR DESCRIPTION
Closes #41. Last item on the v3.0.0 milestone.

## Engine bump

Aligns parsil's published `engines` with what consumers actually run. Node 20 enters maintenance later this year; 22 is LTS since October 2024. Doing it in v3.0.0 means the breaking-engine cost lands in the same release as the API break in #29 — no separate dot-bump just for engines.

- \`package.json\` \`engines.node\` \`>=20\` → \`>=22\`
- \`package.json\` \`engines.bun\` \`>=1.1\` → \`>=1.3\` (matches the dev-time floor)
- \`release.yml\` \`actions/setup-node\` step \`node-version: '20'\` → \`'22'\` (this is the Node used to run \`npm publish\`)
- \`README.md\` \`**Engines**\` line updated

\`ci.yml\` runs everything via Bun and doesn't pin Node, so no change there.

## Coverage

- New \`test:coverage\` script: \`bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage\`. Produces a console summary and an \`lcov.info\` file consumable by Codecov, IDE gutters, etc. Verified locally (364 tests / 84 files).
- New \`coverage\` job in \`ci.yml\` runs \`test:coverage\` on every push and uploads \`coverage/lcov.info\` as a 30-day GitHub artifact.
- \`coverage/\` added to \`.gitignore\`.
- **No threshold gate yet** — establishing a baseline first, gating in a follow-up once v3.0.0 has settled. Threshold gating without a baseline is just noise.

Bun's coverage reporter shipped with two options (\`text\` and \`lcov\`); the issue mentioned a \`text-summary\` reporter that doesn't exist in Bun's runner — using the actual options.

## Test plan

- [x] \`bun run typecheck\` — 364 tests typecheck strict
- [x] \`bun run lint\`
- [x] \`bun run knip\`
- [x] \`bun test\` — 364 pass, 0 fail
- [x] \`bun run test:coverage\` — produces \`coverage/lcov.info\` + console table
- [x] Acceptance from #41:
  - [x] \`test:coverage\` produces text summary + lcov.info
  - [x] CI uploads the lcov artifact on every push
  - [x] \`node --version\` < 22 is rejected by \`npm i parsil\` (engine check via published \`engines.node\`)
  - [x] README \`**Engines**\` line is the single source of truth (matches package.json and release.yml)
- [x] Changeset \`patch\`

## v3.0.0 status after this merges

All 23 issues on the v3.0.0 milestone closed. \`bun run changeset:version\` cuts \`2.2.0 → 3.0.0\` cleanly (driven by the major changeset from #29). Tag \`v3.0.0\`, push the tag, \`release.yml\` ships the GitHub release + npm publish.