### PR TITLE
chore(ci): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,16 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      # Bump npm to a version that supports OIDC trusted publishing.
+      # Node 22 ships with npm 10.x, which is older than what npm
+      # requires (>= 11.5.1). This is a no-op once Node ships a newer
+      # bundled npm.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      # Trusted Publishing: npm verifies the workflow's OIDC token
+      # against the configured trusted publisher on npmjs.com. No
+      # secret needed; the `id-token: write` permission above is what
+      # makes the OIDC token available.
       - name: Publish to NPM
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The v3.0.0 release tag built and pushed a GitHub Release successfully, but \`npm publish\` failed with 403 — npm requires either 2FA-bypass tokens (which expose security risks per npm's UI warning) or **Trusted Publishing** via OIDC.

This switches the workflow to Trusted Publishing.

## Workflow changes

- Drop \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` from the \`Publish to NPM\` step. \`permissions.id-token: write\` (already set) gives npm the OIDC token it verifies against the trusted publisher.
- Add an \`npm install -g npm@latest\` step. Node 22 ships npm 10.x; Trusted Publishing needs >= 11.5.1. Drop this once Node bumps its bundled npm above that threshold.

## Required setup on npmjs.com (one-time, before merging)

1. Go to https://www.npmjs.com/package/parsil/access
2. **Trusted Publishers** → **Add publisher**
3. Configure:
   - **Publisher**: GitHub Actions
   - **Organization or user**: \`salty-max\`
   - **Repository**: \`parsil\`
   - **Workflow filename**: \`release.yml\`
   - **Environment name**: leave blank (we don't use a GitHub Environment)
4. Save
5. (Optional) Delete the \`NPM_TOKEN\` repo secret — \`gh secret delete NPM_TOKEN\` — it's no longer used

## Once merged

The v3.0.0 tag is already on \`main\`, but the existing release workflow run failed at the publish step. To finish the release:

1. Re-trigger by deleting + re-pushing the tag:
   \`\`\`
   git tag -d v3.0.0
   git push origin :refs/tags/v3.0.0
   git tag v3.0.0
   git push origin v3.0.0
   \`\`\`

   Or simpler: re-run the failed step on the existing run via \`gh run rerun --failed <run-id>\` once \`main\` has the new workflow. The rerun checks out the tag, which still points at the same commit; the workflow file is fetched fresh from the **default branch** for reusable jobs but for direct workflow runs it uses the version at the tag commit. Safer path: delete + recreate the tag pointing at the merge commit of this PR (so the new workflow runs).

I'll handle either path after merge.