### PR TITLE
chore(ci): activate npm 11 via corepack instead of self-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,16 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       # Bump npm to a version that supports OIDC trusted publishing.
-      # Node 22 ships with npm 10.x, which is older than what npm
-      # requires (>= 11.5.1). This is a no-op once Node ships a newer
-      # bundled npm.
-      - name: Update npm
-        run: npm install -g npm@latest
+      # Node 22 ships with npm 10.x; OIDC requires >= 11.5.1. We use
+      # corepack (bundled with Node) to swap npm cleanly — `npm i -g
+      # npm@latest` self-upgrades in-place and intermittently breaks
+      # mid-install with "Cannot find module 'promise-retry'". Drop
+      # this step once Node bumps its bundled npm above the threshold.
+      - name: Activate npm 11 via corepack
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.14.0 --activate
+          npm --version
 
       # Trusted Publishing: npm verifies the workflow's OIDC token
       # against the configured trusted publisher on npmjs.com. No


### PR DESCRIPTION
The previous \`npm install -g npm@latest\` step in release.yml failed during the v3.0.0 publish with:

\`\`\`
npm error Cannot find module 'promise-retry'
\`\`\`

This is a known issue when upgrading npm 10.x to 11.x in-place — the self-upgrade leaves the install in an inconsistent state mid-flight. Switching to corepack (bundled with Node 22+) sidesteps the dance: corepack downloads the requested version and activates it cleanly without rewriting the existing global install.

\`\`\`yaml
- name: Activate npm 11 via corepack
  run: |
    corepack enable npm
    corepack prepare npm@11.14.0 --activate
    npm --version
\`\`\`

Pinned \`npm@11.14.0\` (current stable, supports OIDC trusted publishing). Drop this step entirely once Node ships a bundled npm >= 11.5.1.

## After merge

Same procedure as #46 — re-tag v3.0.0 to pick up the fix:

\`\`\`
git tag -d v3.0.0
git push origin :refs/tags/v3.0.0
git pull
git tag v3.0.0
git push origin v3.0.0
\`\`\`

I'll handle that.